### PR TITLE
Improve error reporting for podman operations and  fix pull-secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This tool connects to an OpenShift cluster, collects information about all conta
 ## Features
 
 - 🔌 Connect to OpenShift cluster via API URL and bearer token
-- 🔑 Automatically download and save cluster pull-secret to `.pull-secret`
+- 🔑 Automatically download and save cluster pull-secret to `.pull-secret` (skipped if the file already exists)
 - 📦 Collect container images from:
   - Pods
   - Deployments
@@ -55,7 +55,7 @@ This tool connects to an OpenShift cluster, collects information about all conta
 >    ```
 >    The token used to connect to the cluster is also used to authenticate against the internal registry route. Note that `--tls-verify=false` is used automatically for these pulls, as the route typically uses a self-signed certificate.
 >
-> 2. **Pull Secret Configuration**: The cluster's pull-secret (downloaded automatically or provided via `--pull-secret`) must contain valid credentials for all registries that host the container images you want to analyze. If credentials are missing or invalid, the tool will fail to pull and analyze those images. You can also provide your own pull-secret file in podman-compatible format (JSON with `auths` structure) using the `--pull-secret` option.
+> 2. **Pull Secret Configuration**: The cluster's pull-secret must contain valid credentials for all registries that host the container images you want to analyze. If credentials are missing or invalid, the tool will fail to pull and analyze those images. You can provide your own pull-secret file in podman-compatible format (JSON with `auths` structure) using the `--pull-secret` option. If the pull-secret file already exists at the specified path (default: `.pull-secret`), the tool will use it as-is and **will not** download the cluster pull-secret, avoiding accidental overwrites. The automatic download from the cluster only happens when the file does not exist yet.
 
 ## Requirements
 

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -313,6 +313,7 @@ def main() -> int:
             api_url=args.api_url,
             token=args.token,
             env_file=args.env_file,
+            pull_secret_file=args.pull_secret,
             verify_ssl=args.verify_ssl
         )
         

--- a/src/openshift_client.py
+++ b/src/openshift_client.py
@@ -147,9 +147,16 @@ class OpenShiftClient:
         Download the cluster pull-secret from openshift-config namespace
         and save it to the pull-secret file.
 
+        If the pull-secret file already exists, the download is skipped
+        to avoid overwriting a user-provided pull-secret.
+
         Returns:
             True if successful, False otherwise.
         """
+        if self.pull_secret_file.exists():
+            print(f"✓ Pull secret already exists at {self.pull_secret_file}, skipping download")
+            return True
+
         try:
             core_v1 = self.get_core_v1_api()
             


### PR DESCRIPTION
Extract the actual "Error:" line from podman stderr instead of showing the full output (which includes noise like "Trying to pull..." and "Copying blob..."). Increase debug output limit to show the last 1000 chars of stderr so the real error is not truncated. Also fix pull-secret handling: skip automatic download from the cluster when the file already exists to avoid overwriting a user-provided pull-secret, and pass the --pull-secret path to OpenShiftClient so the check is consistent.