### PR TITLE
Add Docker support with Containerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Credentials and secrets (never send to build context)
+.env
+.pull-secret
+
+# Python virtual environment
+venv/
+.venv/
+env/
+
+# Build output and logs
+output/
+*.log
+image-cgroupsv2-inspector.log
+
+# Git
+.git/
+.gitignore
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+
+# IDE and editor
+.idea/
+.vscode/
+.cursor/
+
+# Test and local artifacts
+rootfs/

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+# image-cgroupsv2-inspector
+# UBI 9 with Python 3.12; entrypoint is the main script.
+FROM registry.access.redhat.com/ubi9/python-312
+
+USER root
+# Install system dependencies: podman (image pull/inspect), acl (extended ACLs for rootfs)
+RUN dnf install -y podman acl && dnf clean all
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application (script + src/)
+COPY image-cgroupsv2-inspector .
+COPY src/ src/
+
+RUN chmod +x /app/image-cgroupsv2-inspector
+
+ENTRYPOINT ["/app/image-cgroupsv2-inspector"]

--- a/README.md
+++ b/README.md
@@ -140,6 +140,41 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Container
+
+You can build and run the tool as a container (UBI 9, Python 3.12). The image uses the main script as the entrypoint.
+
+**Build:**
+
+```bash
+podman build -t image-cgroupsv2-inspector -f Containerfile .
+# or: docker build -t image-cgroupsv2-inspector -f Containerfile .
+```
+
+**Run:**
+
+Mount output and, for `--analyze`, a writable rootfs path. Optionally mount `.env` and `.pull-secret` if you use them.
+
+```bash
+# With API URL and token
+podman run --rm -v ./output:/app/output \
+  image-cgroupsv2-inspector --api-url https://api.mycluster.example.com:6443 --token <token>
+
+# Using .env (mount it into the container)
+podman run --rm -v ./.env:/app/.env -v ./output:/app/output \
+  image-cgroupsv2-inspector
+
+# With analysis (mount rootfs path and optionally pull-secret)
+podman run --rm \
+  -v ./.env:/app/.env \
+  -v ./.pull-secret:/app/.pull-secret \
+  -v ./output:/app/output \
+  -v /tmp/rootfs:/tmp/rootfs \
+  image-cgroupsv2-inspector --rootfs-path /tmp/rootfs --analyze
+```
+
+The container runs as root. For image pulls and analysis, podman runs inside the container; you may need appropriate capabilities or privileges (e.g. `--privileged` or volume mounts for `/var/lib/containers`) depending on your environment.
+
 ## Usage
 
 ### Basic Usage
@@ -509,7 +544,9 @@ image-cgroupsv2-inspector/
 ├── requirements.txt           # Python dependencies
 ├── README.md                  # This file
 ├── LICENSE                    # License file
-├── .gitignore                # Git ignore rules
+├── Containerfile              # Container image definition (UBI 9, Python 3.12)
+├── .dockerignore              # Build context exclusions
+├── .gitignore              # Git ignore rules
 ├── .env                      # Credentials (not in git)
 ├── .pull-secret              # Cluster pull secret (not in git)
 ├── output/                   # CSV output directory (not in git)


### PR DESCRIPTION
- Introduced a Containerfile for building the image-cgroupsv2-inspector container using UBI 9 and Python 3.12.
- Added a .dockerignore file to exclude sensitive files, Python virtual environments, build outputs, and IDE configurations from the Docker build context.
- Updated README with instructions for building and running the container.