### PR TITLE
Add Quay REST API client module for registry scan mode (#22)

### DIFF
--- a/src/quay_client.py
+++ b/src/quay_client.py
@@ -1,0 +1,251 @@
+"""
+Quay REST API Client Module
+Handles interaction with a Quay registry instance via its REST API.
+"""
+
+import logging
+import time
+
+import requests
+import urllib3
+
+logger = logging.getLogger(__name__)
+
+
+class QuayClientError(Exception):
+    """Base exception for QuayClient errors."""
+
+
+class QuayConnectionError(QuayClientError):
+    """Raised when the Quay instance is unreachable."""
+
+
+class QuayAuthenticationError(QuayClientError):
+    """Raised when authentication fails (401/403)."""
+
+
+class QuayNotFoundError(QuayClientError):
+    """Raised when the requested resource is not found (404)."""
+
+
+class QuayAPIError(QuayClientError):
+    """Raised for unexpected API errors (5xx, unexpected status codes)."""
+
+
+class QuayClient:
+    """Client for the Quay REST API.
+
+    Provides methods to list organizations, repositories, and tags
+    from a Quay registry instance (self-hosted or quay.io).
+
+    Args:
+        base_url: Quay instance URL (e.g., "https://quay.example.com").
+        token: OAuth access token or robot account token.
+        verify_ssl: Whether to verify SSL certificates. Defaults to True.
+    """
+
+    DEFAULT_TIMEOUT = 30
+    MAX_RETRIES = 3
+    RETRY_BACKOFF = 1
+
+    def __init__(self, base_url: str, token: str, verify_ssl: bool = True) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_base = f"{self.base_url}/api/v1"
+        self.verify_ssl = verify_ssl
+
+        if not verify_ssl:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            }
+        )
+        self.session.verify = verify_ssl
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        """Send an HTTP request to the Quay API.
+
+        Args:
+            method: HTTP method (GET, POST, etc.).
+            path: API path relative to the API base (e.g., "/user/").
+            **kwargs: Additional keyword arguments passed to requests.Session.request.
+
+        Returns:
+            Parsed JSON response as a dict.
+
+        Raises:
+            QuayAuthenticationError: On 401 or 403 responses.
+            QuayNotFoundError: On 404 responses.
+            QuayConnectionError: On connection or timeout errors.
+            QuayAPIError: On 5xx or other unexpected status codes.
+        """
+        url = f"{self.api_base}{path}"
+        kwargs.setdefault("timeout", self.DEFAULT_TIMEOUT)
+
+        retries = 0
+        while True:
+            try:
+                response = self.session.request(method, url, **kwargs)
+            except requests.ConnectionError as exc:
+                logger.error("Connection error reaching %s: %s", url, exc)
+                raise QuayConnectionError(f"Failed to connect to Quay at {url}: {exc}")
+            except requests.Timeout as exc:
+                logger.error("Request to %s timed out: %s", url, exc)
+                raise QuayConnectionError(f"Request to {url} timed out: {exc}")
+
+            if response.status_code == 429:
+                retries += 1
+                if retries > self.MAX_RETRIES:
+                    logger.error("Rate limit exceeded after %d retries for %s", self.MAX_RETRIES, url)
+                    raise QuayAPIError(f"Rate limit exceeded after {self.MAX_RETRIES} retries for {url}")
+                wait = self.RETRY_BACKOFF * (2 ** (retries - 1))
+                logger.warning(
+                    "Rate limited (429) on %s, retrying in %ss (attempt %d/%d)", url, wait, retries, self.MAX_RETRIES
+                )
+                time.sleep(wait)
+                continue
+
+            break
+
+        if response.status_code == 401:
+            logger.error("Authentication failed for %s: invalid or expired token", url)
+            raise QuayAuthenticationError(f"Invalid or expired token for {url}")
+
+        if response.status_code == 403:
+            logger.error("Insufficient permissions for %s", url)
+            raise QuayAuthenticationError(f"Insufficient permissions for {url}")
+
+        if response.status_code == 404:
+            logger.error("Resource not found: %s", path)
+            raise QuayNotFoundError(f"Resource not found: {path}")
+
+        if response.status_code >= 500:
+            body = response.text
+            logger.error("Server error %d from %s: %s", response.status_code, url, body)
+            raise QuayAPIError(f"Server error {response.status_code} from {url}: {body}")
+
+        if response.status_code >= 400:
+            body = response.text
+            logger.error("Unexpected error %d from %s: %s", response.status_code, url, body)
+            raise QuayAPIError(f"Unexpected error {response.status_code} from {url}: {body}")
+
+        return response.json()
+
+    def test_connection(self) -> bool:
+        """Test connectivity and authentication against the Quay API.
+
+        Makes a request to GET /api/v1/user/ to verify the token is valid
+        and the Quay instance is reachable.
+
+        Returns:
+            True if the connection and authentication are successful.
+
+        Raises:
+            QuayAuthenticationError: If the token is invalid or expired.
+            QuayConnectionError: If the Quay instance is unreachable.
+        """
+        logger.info("Testing connection to Quay at %s", self.base_url)
+        self._request("GET", "/user/")
+        logger.info("Successfully connected to Quay at %s", self.base_url)
+        return True
+
+    def get_organization(self, org: str) -> dict:
+        """Get organization details.
+
+        Args:
+            org: Organization name.
+
+        Returns:
+            Organization metadata dict.
+
+        Raises:
+            QuayNotFoundError: If the organization does not exist.
+            QuayAuthenticationError: If not authorized.
+        """
+        logger.info("Fetching organization details for '%s'", org)
+        return self._request("GET", f"/organization/{org}")
+
+    def list_repositories(self, org: str) -> list[dict]:
+        """List all repositories in an organization.
+
+        Handles pagination automatically, returning all results.
+        Filters out repositories not in "NORMAL" state.
+
+        Args:
+            org: Organization name.
+
+        Returns:
+            List of repository dicts with keys: namespace, name,
+            description, is_public, kind, state, last_modified.
+        """
+        logger.info("Listing repositories for organization '%s'", org)
+        all_repos: list[dict] = []
+        params: dict[str, str] = {"namespace": org}
+        page_num = 0
+
+        while True:
+            page_num += 1
+            logger.debug("Fetching repository page %d for '%s'", page_num, org)
+            data = self._request("GET", "/repository", params=params)
+
+            for repo in data.get("repositories", []):
+                state = repo.get("state", "NORMAL")
+                if state != "NORMAL":
+                    logger.warning(
+                        "Skipping repository '%s/%s' with non-NORMAL state: %s",
+                        repo.get("namespace", org),
+                        repo.get("name", "unknown"),
+                        state,
+                    )
+                    continue
+                all_repos.append(repo)
+
+            next_page = data.get("next_page")
+            if not next_page:
+                break
+            params["next_page"] = next_page
+
+        logger.info("Found %d repositories in organization '%s'", len(all_repos), org)
+        return all_repos
+
+    def list_tags(self, org: str, repo: str, limit: int = 100) -> list[dict]:
+        """List all active tags for a repository.
+
+        Handles pagination automatically, returning all results.
+        Only returns active tags (not deleted/expired).
+
+        Args:
+            org: Organization name.
+            repo: Repository name.
+            limit: Number of tags per page (max 100).
+
+        Returns:
+            List of tag dicts with keys: name, manifest_digest,
+            size, last_modified, start_ts.
+        """
+        logger.info("Listing tags for repository '%s/%s'", org, repo)
+        all_tags: list[dict] = []
+        page = 1
+
+        while True:
+            logger.debug("Fetching tag page %d for '%s/%s'", page, org, repo)
+            params = {
+                "onlyActiveTags": "true",
+                "limit": str(limit),
+                "page": str(page),
+            }
+            data = self._request("GET", f"/repository/{org}/{repo}/tag/", params=params)
+
+            tags = data.get("tags", [])
+            all_tags.extend(tags)
+            logger.debug("Retrieved %d tags on page %d for '%s/%s'", len(tags), page, org, repo)
+
+            if not data.get("has_additional", False):
+                break
+            page += 1
+
+        logger.info("Found %d tags for repository '%s/%s'", len(all_tags), org, repo)
+        return all_tags

--- a/tests/test_quay_client.py
+++ b/tests/test_quay_client.py
@@ -1,0 +1,399 @@
+"""Tests for the QuayClient module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from src.quay_client import (
+    QuayAPIError,
+    QuayAuthenticationError,
+    QuayClient,
+    QuayConnectionError,
+    QuayNotFoundError,
+)
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock requests.Session."""
+    with patch("src.quay_client.requests.Session") as mock:
+        session_instance = MagicMock()
+        mock.return_value = session_instance
+        yield session_instance
+
+
+@pytest.fixture
+def client(mock_session):
+    """Create a QuayClient with mocked session."""
+    return QuayClient(
+        base_url="https://quay.example.com",
+        token="test-token",
+        verify_ssl=True,
+    )
+
+
+class TestQuayClientInit:
+    """Test QuayClient initialization."""
+
+    def test_session_created_with_correct_headers(self, client, mock_session):
+        mock_session.headers.update.assert_called_once_with(
+            {
+                "Authorization": "Bearer test-token",
+                "Accept": "application/json",
+            }
+        )
+
+    def test_base_url_trailing_slash_stripped(self, mock_session):
+        c = QuayClient(base_url="https://quay.example.com/", token="tok")
+        assert c.base_url == "https://quay.example.com"
+
+    def test_api_base_url_constructed(self, client):
+        assert client.api_base == "https://quay.example.com/api/v1"
+
+    def test_ssl_verification_propagated(self, mock_session):
+        QuayClient(base_url="https://quay.example.com", token="tok", verify_ssl=True)
+        assert mock_session.verify is True
+
+    def test_ssl_verification_disabled(self, mock_session):
+        with patch("src.quay_client.urllib3.disable_warnings") as mock_disable:
+            QuayClient(base_url="https://quay.example.com", token="tok", verify_ssl=False)
+            mock_disable.assert_called_once()
+            assert mock_session.verify is False
+
+
+class TestQuayClientTestConnection:
+    """Test the test_connection method."""
+
+    def test_successful_connection(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"username": "testuser"}
+        mock_session.request.return_value = response
+
+        assert client.test_connection() is True
+        mock_session.request.assert_called_once_with(
+            "GET",
+            "https://quay.example.com/api/v1/user/",
+            timeout=30,
+        )
+
+    def test_401_raises_authentication_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 401
+        response.text = "Unauthorized"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayAuthenticationError, match=r"(?i)invalid or expired token"):
+            client.test_connection()
+
+    def test_connection_error_raises_quay_connection_error(self, client, mock_session):
+        mock_session.request.side_effect = requests.ConnectionError("Connection refused")
+
+        with pytest.raises(QuayConnectionError, match="Failed to connect"):
+            client.test_connection()
+
+    def test_timeout_raises_quay_connection_error(self, client, mock_session):
+        mock_session.request.side_effect = requests.Timeout("timed out")
+
+        with pytest.raises(QuayConnectionError, match="timed out"):
+            client.test_connection()
+
+
+class TestQuayClientGetOrganization:
+    """Test the get_organization method."""
+
+    def test_successful_response(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"name": "myorg", "email": "org@example.com"}
+        mock_session.request.return_value = response
+
+        result = client.get_organization("myorg")
+        assert result == {"name": "myorg", "email": "org@example.com"}
+        mock_session.request.assert_called_once_with(
+            "GET",
+            "https://quay.example.com/api/v1/organization/myorg",
+            timeout=30,
+        )
+
+    def test_404_raises_not_found_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 404
+        response.text = "Not Found"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayNotFoundError, match="not found"):
+            client.get_organization("nonexistent")
+
+    def test_401_raises_authentication_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 401
+        response.text = "Unauthorized"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayAuthenticationError):
+            client.get_organization("myorg")
+
+
+class TestQuayClientListRepositories:
+    """Test the list_repositories method."""
+
+    def test_single_page(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "repositories": [
+                {
+                    "namespace": "myorg",
+                    "name": "repo1",
+                    "description": "First repo",
+                    "is_public": False,
+                    "kind": "image",
+                    "state": "NORMAL",
+                    "last_modified": 1704067200,
+                }
+            ],
+        }
+        mock_session.request.return_value = response
+
+        repos = client.list_repositories("myorg")
+        assert len(repos) == 1
+        assert repos[0]["name"] == "repo1"
+        assert mock_session.request.call_count == 1
+
+    def test_multi_page_pagination(self, client, mock_session):
+        page1_response = MagicMock()
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "repositories": [
+                {"namespace": "myorg", "name": "repo1", "state": "NORMAL"},
+            ],
+            "next_page": "token123",
+        }
+        page2_response = MagicMock()
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "repositories": [
+                {"namespace": "myorg", "name": "repo2", "state": "NORMAL"},
+            ],
+            "next_page": "token456",
+        }
+        page3_response = MagicMock()
+        page3_response.status_code = 200
+        page3_response.json.return_value = {
+            "repositories": [
+                {"namespace": "myorg", "name": "repo3", "state": "NORMAL"},
+            ],
+        }
+        mock_session.request.side_effect = [page1_response, page2_response, page3_response]
+
+        repos = client.list_repositories("myorg")
+        assert len(repos) == 3
+        assert [r["name"] for r in repos] == ["repo1", "repo2", "repo3"]
+        assert mock_session.request.call_count == 3
+
+    def test_empty_organization(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"repositories": []}
+        mock_session.request.return_value = response
+
+        repos = client.list_repositories("emptyorg")
+        assert repos == []
+
+    def test_filters_non_normal_state(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "repositories": [
+                {"namespace": "myorg", "name": "good-repo", "state": "NORMAL"},
+                {"namespace": "myorg", "name": "deleting-repo", "state": "MARKED_FOR_DELETION"},
+                {"namespace": "myorg", "name": "another-good", "state": "NORMAL"},
+            ],
+        }
+        mock_session.request.return_value = response
+
+        repos = client.list_repositories("myorg")
+        assert len(repos) == 2
+        assert [r["name"] for r in repos] == ["good-repo", "another-good"]
+
+    def test_401_raises_authentication_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 401
+        response.text = "Unauthorized"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayAuthenticationError):
+            client.list_repositories("myorg")
+
+
+class TestQuayClientListTags:
+    """Test the list_tags method."""
+
+    def test_single_page(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "tags": [
+                {
+                    "name": "v1.0",
+                    "manifest_digest": "sha256:abc123",
+                    "size": 123456789,
+                    "last_modified": "Mon, 01 Jan 2024 00:00:00 -0000",
+                    "start_ts": 1704067200,
+                }
+            ],
+            "page": 1,
+            "has_additional": False,
+        }
+        mock_session.request.return_value = response
+
+        tags = client.list_tags("myorg", "myrepo")
+        assert len(tags) == 1
+        assert tags[0]["name"] == "v1.0"
+        assert mock_session.request.call_count == 1
+
+    def test_multi_page_pagination(self, client, mock_session):
+        page1_response = MagicMock()
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "tags": [
+                {
+                    "name": "v1.0",
+                    "manifest_digest": "sha256:aaa",
+                    "size": 100,
+                    "last_modified": "Mon, 01 Jan 2024 00:00:00 -0000",
+                    "start_ts": 1704067200,
+                },
+                {
+                    "name": "v1.1",
+                    "manifest_digest": "sha256:bbb",
+                    "size": 200,
+                    "last_modified": "Tue, 02 Jan 2024 00:00:00 -0000",
+                    "start_ts": 1704153600,
+                },
+            ],
+            "page": 1,
+            "has_additional": True,
+        }
+        page2_response = MagicMock()
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "tags": [
+                {
+                    "name": "v2.0",
+                    "manifest_digest": "sha256:ccc",
+                    "size": 300,
+                    "last_modified": "Wed, 03 Jan 2024 00:00:00 -0000",
+                    "start_ts": 1704240000,
+                },
+            ],
+            "page": 2,
+            "has_additional": False,
+        }
+        mock_session.request.side_effect = [page1_response, page2_response]
+
+        tags = client.list_tags("myorg", "myrepo")
+        assert len(tags) == 3
+        assert [t["name"] for t in tags] == ["v1.0", "v1.1", "v2.0"]
+        assert mock_session.request.call_count == 2
+
+    def test_empty_repo(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"tags": [], "page": 1, "has_additional": False}
+        mock_session.request.return_value = response
+
+        tags = client.list_tags("myorg", "emptyrepo")
+        assert tags == []
+
+    def test_404_raises_not_found_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 404
+        response.text = "Not Found"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayNotFoundError):
+            client.list_tags("myorg", "nonexistent")
+
+
+class TestQuayClientRetry:
+    """Test retry logic for rate limiting."""
+
+    @patch("src.quay_client.time.sleep")
+    def test_429_retries_then_succeeds(self, mock_sleep, client, mock_session):
+        rate_limit_response = MagicMock()
+        rate_limit_response.status_code = 429
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {"username": "testuser"}
+
+        mock_session.request.side_effect = [
+            rate_limit_response,
+            rate_limit_response,
+            success_response,
+        ]
+
+        result = client.test_connection()
+        assert result is True
+        assert mock_session.request.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(1)
+        mock_sleep.assert_any_call(2)
+
+    @patch("src.quay_client.time.sleep")
+    def test_429_exhausts_retries(self, mock_sleep, client, mock_session):
+        rate_limit_response = MagicMock()
+        rate_limit_response.status_code = 429
+
+        mock_session.request.return_value = rate_limit_response
+
+        with pytest.raises(QuayAPIError, match="Rate limit exceeded"):
+            client.test_connection()
+        assert mock_session.request.call_count == 4  # 1 initial + 3 retries
+        assert mock_sleep.call_count == 3
+
+
+class TestQuayClientErrorHandling:
+    """Test error handling for various failure modes."""
+
+    def test_500_raises_api_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "Internal Server Error"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayAPIError, match="Server error 500"):
+            client.test_connection()
+
+    def test_connection_error_raises_quay_connection_error(self, client, mock_session):
+        mock_session.request.side_effect = requests.ConnectionError("refused")
+
+        with pytest.raises(QuayConnectionError, match="Failed to connect"):
+            client.get_organization("myorg")
+
+    def test_timeout_raises_quay_connection_error(self, client, mock_session):
+        mock_session.request.side_effect = requests.Timeout("timed out")
+
+        with pytest.raises(QuayConnectionError, match="timed out"):
+            client.list_repositories("myorg")
+
+    def test_malformed_json_raises_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.side_effect = requests.exceptions.JSONDecodeError("", "", 0)
+        mock_session.request.return_value = response
+
+        with pytest.raises(requests.exceptions.JSONDecodeError):
+            client.test_connection()
+
+    def test_403_raises_authentication_error(self, client, mock_session):
+        response = MagicMock()
+        response.status_code = 403
+        response.text = "Forbidden"
+        mock_session.request.return_value = response
+
+        with pytest.raises(QuayAuthenticationError, match="Insufficient permissions"):
+            client.get_organization("myorg")


### PR DESCRIPTION
Introduce QuayClient class (src/quay_client.py) that wraps the Quay v1 REST API with session management, automatic pagination, rate-limit retry with exponential backoff, and custom exception hierarchy. This is the first building block for the registry scan mode (epic #21).