### PR TITLE
Add registry image collector for Quay scan mode (#23)

### DIFF
--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -1,0 +1,261 @@
+"""
+Registry Image Collector Module
+Collects container image references from a Quay registry organization,
+producing image records compatible with the unified CSV schema.
+"""
+
+import csv
+import fnmatch
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from .quay_client import QuayClient, QuayClientError
+
+logger = logging.getLogger(__name__)
+
+CSV_COLUMNS = [
+    "source",
+    "container_name",
+    "namespace",
+    "object_type",
+    "object_name",
+    "registry_org",
+    "registry_repo",
+    "image_name",
+    "image_id",
+    "java_binary",
+    "java_version",
+    "java_cgroup_v2_compatible",
+    "node_binary",
+    "node_version",
+    "node_cgroup_v2_compatible",
+    "dotnet_binary",
+    "dotnet_version",
+    "dotnet_cgroup_v2_compatible",
+    "analysis_error",
+]
+
+
+class RegistryCollector:
+    """Collects container image references from a Quay registry.
+
+    Uses QuayClient to enumerate repositories and tags in a Quay
+    organization, producing image records compatible with the unified
+    CSV schema (source="registry").
+
+    Args:
+        quay_client: An initialized QuayClient instance.
+        registry_host: Registry hostname for building image references
+            (e.g., "quay.example.com" or "quay.io").
+    """
+
+    def __init__(self, quay_client: QuayClient, registry_host: str) -> None:
+        self.quay_client = quay_client
+        self.registry_host = registry_host
+
+    def _build_image_record(self, org: str, repo: str, tag: str) -> dict:
+        """Build a single image record dict with the unified schema.
+
+        Args:
+            org: Quay organization name.
+            repo: Repository name.
+            tag: Tag name.
+
+        Returns:
+            Image record dict with all unified schema keys.
+        """
+        return {
+            "source": "registry",
+            "container_name": "",
+            "namespace": "",
+            "object_type": "",
+            "object_name": "",
+            "registry_org": org,
+            "registry_repo": repo,
+            "image_name": f"{self.registry_host}/{org}/{repo}:{tag}",
+            "image_id": "",
+        }
+
+    def _filter_tags(
+        self,
+        tags: list[dict],
+        include_tags: list[str] | None = None,
+        exclude_tags: list[str] | None = None,
+        latest_only: int | None = None,
+    ) -> list[dict]:
+        """Filter tags by include/exclude glob patterns and recency.
+
+        Processing order:
+        1. Apply include patterns (keep only matching tags). Default: ["*"]
+        2. Apply exclude patterns (remove matching tags)
+        3. Sort by start_ts descending (most recent first)
+        4. If latest_only is set, take only the first N tags
+
+        Uses fnmatch.fnmatch for glob matching on tag names.
+
+        Args:
+            tags: List of tag dicts from QuayClient.list_tags().
+            include_tags: Glob patterns to include (e.g., ["v*", "release-*"]).
+            exclude_tags: Glob patterns to exclude (e.g., ["*-dev", "*-snapshot"]).
+            latest_only: Keep only the N most recent tags.
+
+        Returns:
+            Filtered list of tag dicts.
+        """
+        include_patterns = include_tags if include_tags is not None else ["*"]
+        exclude_patterns = exclude_tags or []
+
+        filtered = []
+        for tag in tags:
+            name = tag.get("name", "")
+            if any(fnmatch.fnmatch(name, p) for p in include_patterns):
+                filtered.append(tag)
+
+        result = []
+        for tag in filtered:
+            name = tag.get("name", "")
+            excluded = False
+            for pattern in exclude_patterns:
+                if fnmatch.fnmatch(name, pattern):
+                    logger.debug("Tag '%s' excluded by pattern '%s'", name, pattern)
+                    excluded = True
+                    break
+            if not excluded:
+                result.append(tag)
+
+        result.sort(key=lambda t: t.get("start_ts", 0), reverse=True)
+
+        if latest_only is not None:
+            total = len(result)
+            result = result[:latest_only]
+            logger.debug(
+                "Applying latest_only=%d, keeping %d of %d tags",
+                latest_only,
+                len(result),
+                total,
+            )
+
+        return result
+
+    def collect_images(
+        self,
+        org: str,
+        repo: str | None = None,
+        include_tags: list[str] | None = None,
+        exclude_tags: list[str] | None = None,
+        latest_only: int | None = None,
+    ) -> list[dict]:
+        """Collect image references from a Quay organization.
+
+        Args:
+            org: Quay organization name.
+            repo: Specific repository to scan. If None, scans all repos
+                in the organization.
+            include_tags: Glob patterns for tags to include (default: ["*"]).
+            exclude_tags: Glob patterns for tags to exclude
+                (e.g., ["*-dev", "*-snapshot"]).
+            latest_only: If set, only include the N most recent tags per
+                repo, sorted by start_ts descending.
+
+        Returns:
+            List of image record dicts with the unified schema.
+        """
+        logger.info("Collecting images from organization '%s'", org)
+
+        if repo is not None:
+            repos = [{"name": repo}]
+        else:
+            repos = self.quay_client.list_repositories(org)
+
+        all_images: list[dict] = []
+        seen_image_names: set[str] = set()
+        repos_scanned = 0
+
+        for repo_info in repos:
+            repo_name = repo_info["name"]
+
+            try:
+                tags = self.quay_client.list_tags(org, repo_name)
+            except QuayClientError as exc:
+                if repo is not None:
+                    raise
+                logger.warning(
+                    "Failed to list tags for '%s/%s': %s — skipping",
+                    org,
+                    repo_name,
+                    exc,
+                )
+                continue
+
+            logger.info(
+                "Scanning repository '%s/%s' (%d active tags)",
+                org,
+                repo_name,
+                len(tags),
+            )
+
+            filtered = self._filter_tags(tags, include_tags, exclude_tags, latest_only)
+
+            if not filtered:
+                logger.warning(
+                    "Repository '%s/%s' has no active tags after filtering",
+                    org,
+                    repo_name,
+                )
+                continue
+
+            for tag in filtered:
+                record = self._build_image_record(org, repo_name, tag["name"])
+                image_name = record["image_name"]
+                if image_name not in seen_image_names:
+                    seen_image_names.add(image_name)
+                    all_images.append(record)
+
+            repos_scanned += 1
+
+        logger.info(
+            "Collected %d images from %d repositories",
+            len(all_images),
+            repos_scanned,
+        )
+        return all_images
+
+    def save_to_csv(
+        self,
+        images: list[dict],
+        output_dir: str = "output",
+    ) -> str:
+        """Save collected images to a CSV file.
+
+        The CSV uses the unified schema columns. Only the collection-phase
+        columns are populated; analysis columns are left empty (they will
+        be filled by image_analyzer.py later).
+
+        The filename format for registry mode is:
+            {registry_host}-{org}-{YYYYMMDD}-{HHMMSS}.csv
+
+        Args:
+            images: List of image record dicts.
+            output_dir: Output directory (default: "output").
+
+        Returns:
+            Path to the saved CSV file.
+        """
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        org = images[0]["registry_org"] if images else "unknown"
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        filename = f"{self.registry_host}-{org}-{timestamp}.csv"
+        filepath = output_path / filename
+
+        with open(filepath, "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+            writer.writeheader()
+            for image in images:
+                row = {col: image.get(col, "") for col in CSV_COLUMNS}
+                writer.writerow(row)
+
+        logger.info("Saved %d image records to %s", len(images), filepath)
+        return str(filepath)

--- a/tests/test_registry_collector.py
+++ b/tests/test_registry_collector.py
@@ -1,0 +1,354 @@
+"""Tests for the RegistryCollector module."""
+
+import csv
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.quay_client import QuayAPIError, QuayNotFoundError
+from src.registry_collector import CSV_COLUMNS, RegistryCollector
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_TAGS = [
+    {
+        "name": "17",
+        "manifest_digest": "sha256:aaa",
+        "size": 100,
+        "last_modified": "Mon, 31 Mar 2026 00:00:00 -0000",
+        "start_ts": 1743379200,
+    },
+    {
+        "name": "latest",
+        "manifest_digest": "sha256:bbb",
+        "size": 100,
+        "last_modified": "Sun, 30 Mar 2026 00:00:00 -0000",
+        "start_ts": 1743292800,
+    },
+    {
+        "name": "dev",
+        "manifest_digest": "sha256:ccc",
+        "size": 100,
+        "last_modified": "Sat, 29 Mar 2026 00:00:00 -0000",
+        "start_ts": 1743206400,
+    },
+]
+
+
+@pytest.fixture
+def mock_quay_client():
+    """Create a mock QuayClient."""
+    client = MagicMock()
+    client.list_repositories.return_value = [
+        {"namespace": "testorg", "name": "java-compatible", "state": "NORMAL"},
+        {"namespace": "testorg", "name": "node-compatible", "state": "NORMAL"},
+    ]
+    client.list_tags.return_value = list(SAMPLE_TAGS)
+    return client
+
+
+@pytest.fixture
+def collector(mock_quay_client):
+    """Create a RegistryCollector with mocked QuayClient."""
+    return RegistryCollector(
+        quay_client=mock_quay_client,
+        registry_host="quay.example.com",
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryCollectorCollectImages
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCollectorCollectImages:
+    """Test the collect_images method."""
+
+    def test_collect_all_repos(self, collector, mock_quay_client):
+        images = collector.collect_images("testorg")
+
+        mock_quay_client.list_repositories.assert_called_once_with("testorg")
+        assert mock_quay_client.list_tags.call_count == 2
+        assert len(images) == 6
+
+    def test_collect_specific_repo(self, collector, mock_quay_client):
+        images = collector.collect_images("testorg", repo="java-compatible")
+
+        mock_quay_client.list_repositories.assert_not_called()
+        mock_quay_client.list_tags.assert_called_once_with("testorg", "java-compatible")
+        assert len(images) == 3
+
+    def test_image_record_has_all_schema_keys(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+
+        expected_keys = {
+            "source",
+            "container_name",
+            "namespace",
+            "object_type",
+            "object_name",
+            "registry_org",
+            "registry_repo",
+            "image_name",
+            "image_id",
+        }
+        for img in images:
+            assert expected_keys.issubset(img.keys())
+
+    def test_source_is_registry(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        assert all(img["source"] == "registry" for img in images)
+
+    def test_openshift_fields_empty(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        for img in images:
+            assert img["container_name"] == ""
+            assert img["namespace"] == ""
+            assert img["object_type"] == ""
+            assert img["object_name"] == ""
+
+    def test_registry_org_set(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        assert all(img["registry_org"] == "testorg" for img in images)
+
+    def test_registry_repo_set(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        assert all(img["registry_repo"] == "java-compatible" for img in images)
+
+    def test_image_name_format(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        tag_names = {"17", "latest", "dev"}
+        for img in images:
+            assert img["image_name"].startswith("quay.example.com/testorg/java-compatible:")
+            tag = img["image_name"].split(":")[-1]
+            assert tag in tag_names
+
+    def test_image_id_empty(self, collector):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        assert all(img["image_id"] == "" for img in images)
+
+    def test_deduplication(self, collector, mock_quay_client):
+        mock_quay_client.list_repositories.return_value = [
+            {"namespace": "testorg", "name": "same-repo", "state": "NORMAL"},
+            {"namespace": "testorg", "name": "same-repo", "state": "NORMAL"},
+        ]
+        mock_quay_client.list_tags.return_value = [
+            {"name": "v1.0", "manifest_digest": "sha256:aaa", "size": 100, "start_ts": 1743379200},
+        ]
+
+        images = collector.collect_images("testorg")
+        assert len(images) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryCollectorFilterTags
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCollectorFilterTags:
+    """Test tag filtering logic."""
+
+    def test_no_filters_returns_all(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS)
+        assert len(result) == 3
+
+    def test_include_pattern(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, include_tags=["1*"])
+        assert len(result) == 1
+        assert result[0]["name"] == "17"
+
+    def test_exclude_dev(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, exclude_tags=["dev"])
+        assert len(result) == 2
+        names = [t["name"] for t in result]
+        assert "dev" not in names
+
+    def test_exclude_glob(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, exclude_tags=["*dev*"])
+        assert len(result) == 2
+        names = [t["name"] for t in result]
+        assert "dev" not in names
+
+    def test_include_and_exclude_combined(self, collector):
+        result = collector._filter_tags(
+            SAMPLE_TAGS,
+            include_tags=["*"],
+            exclude_tags=["dev"],
+        )
+        assert len(result) == 2
+        names = [t["name"] for t in result]
+        assert "17" in names
+        assert "latest" in names
+
+    def test_latest_only_1(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, latest_only=1)
+        assert len(result) == 1
+        assert result[0]["name"] == "17"
+
+    def test_latest_only_2(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, latest_only=2)
+        assert len(result) == 2
+        assert result[0]["name"] == "17"
+        assert result[1]["name"] == "latest"
+
+    def test_latest_only_exceeds_count(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, latest_only=10)
+        assert len(result) == 3
+
+    def test_exclude_latest(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, exclude_tags=["latest"])
+        names = [t["name"] for t in result]
+        assert "latest" not in names
+        assert len(result) == 2
+
+    def test_all_tags_filtered_out(self, collector):
+        result = collector._filter_tags(SAMPLE_TAGS, include_tags=["nonexistent-*"])
+        assert result == []
+
+    def test_processing_order(self, collector):
+        result = collector._filter_tags(
+            SAMPLE_TAGS,
+            include_tags=["*"],
+            exclude_tags=["dev"],
+            latest_only=1,
+        )
+        assert len(result) == 1
+        assert result[0]["name"] == "17"
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryCollectorSaveToCSV
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCollectorSaveToCSV:
+    """Test CSV output."""
+
+    def test_csv_file_created(self, collector, tmp_path):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(tmp_path))
+        assert Path(filepath).exists()
+
+    def test_csv_filename_format(self, collector, tmp_path):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(tmp_path))
+        filename = Path(filepath).name
+        assert filename.startswith("quay.example.com-testorg-")
+        assert filename.endswith(".csv")
+
+    def test_csv_header_columns(self, collector, tmp_path):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(tmp_path))
+
+        with open(filepath) as f:
+            reader = csv.reader(f)
+            header = next(reader)
+        assert header == CSV_COLUMNS
+
+    def test_csv_row_count(self, collector, tmp_path):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(tmp_path))
+
+        with open(filepath) as f:
+            reader = csv.reader(f)
+            next(reader)
+            rows = list(reader)
+        assert len(rows) == 3
+
+    def test_csv_data_matches_records(self, collector, tmp_path):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(tmp_path))
+
+        with open(filepath) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        for row in rows:
+            assert row["source"] == "registry"
+            assert row["registry_org"] == "testorg"
+            assert row["registry_repo"] == "java-compatible"
+            assert row["image_name"].startswith("quay.example.com/testorg/java-compatible:")
+
+    def test_output_dir_created(self, collector, tmp_path):
+        new_dir = tmp_path / "nested" / "output"
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(new_dir))
+        assert Path(filepath).exists()
+        assert new_dir.exists()
+
+    def test_analysis_columns_empty(self, collector, tmp_path):
+        images = collector.collect_images("testorg", repo="java-compatible")
+        filepath = collector.save_to_csv(images, output_dir=str(tmp_path))
+
+        analysis_cols = [
+            "java_binary",
+            "java_version",
+            "java_cgroup_v2_compatible",
+            "node_binary",
+            "node_version",
+            "node_cgroup_v2_compatible",
+            "dotnet_binary",
+            "dotnet_version",
+            "dotnet_cgroup_v2_compatible",
+            "analysis_error",
+        ]
+
+        with open(filepath) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                for col in analysis_cols:
+                    assert row[col] == "", f"Expected '{col}' to be empty, got '{row[col]}'"
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryCollectorErrorHandling
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCollectorErrorHandling:
+    """Test error handling."""
+
+    def test_list_tags_failure_skips_repo(self, collector, mock_quay_client):
+        def list_tags_side_effect(org, repo_name):
+            if repo_name == "java-compatible":
+                raise QuayNotFoundError(f"Not found: {repo_name}")
+            return list(SAMPLE_TAGS)
+
+        mock_quay_client.list_tags.side_effect = list_tags_side_effect
+
+        images = collector.collect_images("testorg")
+        assert len(images) == 3
+        image_names = [img["image_name"] for img in images]
+        assert all("node-compatible" in name for name in image_names)
+
+    def test_list_tags_api_error_continues(self, collector, mock_quay_client):
+        def list_tags_side_effect(org, repo_name):
+            if repo_name == "java-compatible":
+                raise QuayAPIError("Server error")
+            return list(SAMPLE_TAGS)
+
+        mock_quay_client.list_tags.side_effect = list_tags_side_effect
+
+        images = collector.collect_images("testorg")
+        assert len(images) == 3
+
+    def test_specific_repo_not_found_propagates(self, collector, mock_quay_client):
+        mock_quay_client.list_tags.side_effect = QuayNotFoundError("Not found")
+
+        with pytest.raises(QuayNotFoundError):
+            collector.collect_images("testorg", repo="nonexistent")
+
+    def test_empty_org(self, collector, mock_quay_client):
+        mock_quay_client.list_repositories.return_value = []
+        images = collector.collect_images("emptyorg")
+        assert images == []
+
+    def test_repo_with_zero_tags_after_filtering(self, collector, mock_quay_client):
+        mock_quay_client.list_tags.return_value = [
+            {"name": "dev-only", "manifest_digest": "sha256:aaa", "size": 100, "start_ts": 1743379200},
+        ]
+        images = collector.collect_images("testorg", exclude_tags=["dev-*"])
+        assert images == []


### PR DESCRIPTION
Introduce RegistryCollector (src/registry_collector.py) that uses QuayClient to enumerate repositories and tags in a Quay organization, producing image records with the unified CSV schema (source, registry_org, registry_repo columns). Supports tag filtering via include/exclude glob patterns and latest_only recency limit, automatic deduplication, and graceful per-repo error handling.