### PR TITLE
Refactor image analyzer for registry context (#24)

### DIFF
--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -1,0 +1,151 @@
+"""
+Analysis Orchestrator Module
+
+Orchestrates image analysis with incremental CSV saving.
+Works with image records from both OpenShift and registry collectors.
+"""
+
+import csv
+import logging
+import traceback
+
+from .image_analyzer import ImageAnalysisResult, ImageAnalyzer
+from .registry_collector import CSV_COLUMNS
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisOrchestrator:
+    """Orchestrates image analysis with incremental CSV saving.
+
+    Source-agnostic: works with image records (plain dicts) from both
+    OpenShift and registry collectors.
+
+    Args:
+        rootfs_path: Path where rootfs directory exists.
+        pull_secret_path: Path to pull-secret for authentication.
+        internal_registry_route: External hostname for OpenShift internal
+            registry (only for OpenShift mode, None for registry mode).
+        openshift_token: Bearer token for internal registry auth
+            (only for OpenShift mode, None for registry mode).
+    """
+
+    def __init__(
+        self,
+        rootfs_path: str,
+        pull_secret_path: str | None = None,
+        internal_registry_route: str | None = None,
+        openshift_token: str | None = None,
+    ) -> None:
+        self.rootfs_path = rootfs_path
+        self.pull_secret_path = pull_secret_path
+        self.internal_registry_route = internal_registry_route
+        self.openshift_token = openshift_token
+
+    def _save_csv(self, images: list[dict], filepath: str) -> None:
+        """Write image records to CSV using the unified schema."""
+        with open(filepath, "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+            writer.writeheader()
+            for image in images:
+                row = {col: image.get(col, "") for col in CSV_COLUMNS}
+                writer.writerow(row)
+
+    def analyze_images(
+        self,
+        images: list[dict],
+        csv_filepath: str | None = None,
+        debug: bool = False,
+        logger: logging.Logger | None = None,
+    ) -> tuple[int, str | None]:
+        """Analyze images and save CSV incrementally.
+
+        For each unique image_name:
+        1. Call ImageAnalyzer.analyze_image()
+        2. Update ALL records in ``images`` that share this image_name
+           with the analysis results
+        3. Write the FULL CSV with current progress (crash resilience)
+        4. Continue to next image
+
+        After all images are analyzed, do a final CSV save with all rows.
+
+        Args:
+            images: List of image record dicts (unified schema).
+                These dicts are MUTATED IN PLACE with analysis results.
+            csv_filepath: Path for incremental CSV saving.
+                If None, no CSV is written (results only in dicts).
+            debug: Enable debug output.
+            logger: Optional logger for file logging.
+
+        Returns:
+            Tuple of (images_analyzed_count, csv_filepath or None).
+        """
+        analyzer = ImageAnalyzer(
+            self.rootfs_path,
+            self.pull_secret_path,
+            self.internal_registry_route,
+            self.openshift_token,
+        )
+
+        unique_image_names: list[str] = []
+        seen: set[str] = set()
+        for record in images:
+            name = record.get("image_name", "")
+            if name and name not in seen:
+                seen.add(name)
+                unique_image_names.append(name)
+
+        total = len(unique_image_names)
+        analyzed_count = 0
+        results_cache: dict[str, ImageAnalysisResult] = {}
+
+        for idx, image_name in enumerate(unique_image_names, 1):
+            print(f"[{idx}/{total}] Analyzing: {image_name}")
+            if logger:
+                logger.info("[%d/%d] Analyzing image: %s", idx, total, image_name)
+
+            try:
+                result = analyzer.analyze_image(image_name, debug=debug)
+                results_cache[image_name] = result
+                analyzed_count += 1
+            except Exception as exc:
+                print(f"  Error analyzing image: {exc}")
+                if logger:
+                    logger.error("Error analyzing image %s: %s", image_name, exc)
+                if debug:
+                    traceback.print_exc()
+                results_cache[image_name] = ImageAnalysisResult(image_name=image_name, image_id="", error=str(exc))
+
+            self._apply_results(images, results_cache)
+
+            if csv_filepath:
+                self._save_csv(images, csv_filepath)
+                row_count = len(images)
+                print(f"\U0001f4be Progress saved: {row_count} rows")
+
+        self._apply_results(images, results_cache)
+
+        if csv_filepath:
+            self._save_csv(images, csv_filepath)
+
+        return analyzed_count, csv_filepath
+
+    @staticmethod
+    def _apply_results(
+        images: list[dict],
+        results_cache: dict[str, ImageAnalysisResult],
+    ) -> None:
+        """Apply cached analysis results to all matching image records."""
+        for record in images:
+            result = results_cache.get(record.get("image_name", ""))
+            if result:
+                record["java_binary"] = result.java_found
+                record["java_version"] = result.java_versions
+                record["java_cgroup_v2_compatible"] = result.java_compatible
+                record["node_binary"] = result.node_found
+                record["node_version"] = result.node_versions
+                record["node_cgroup_v2_compatible"] = result.node_compatible
+                record["dotnet_binary"] = result.dotnet_found
+                record["dotnet_version"] = result.dotnet_versions
+                record["dotnet_cgroup_v2_compatible"] = result.dotnet_compatible
+                record["analysis_error"] = result.error or ""

--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -1,0 +1,51 @@
+"""
+Authentication Utilities Module
+
+Provides helper functions for generating container registry
+authentication files compatible with podman.
+"""
+
+import base64
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def generate_registry_auth_json(
+    registry_host: str,
+    token: str,
+    output_path: str = ".pull-secret-registry",
+) -> str:
+    """Generate a podman-compatible auth.json from a Quay token.
+
+    For OAuth tokens, uses "$oauthtoken" as the username.
+    The generated file is in the standard podman auth format.
+
+    If the file already exists, it is overwritten.
+
+    Args:
+        registry_host: Registry hostname (e.g., "quay.example.com").
+        token: Quay OAuth token or robot account token.
+        output_path: Path to write the auth.json file.
+
+    Returns:
+        Absolute path to the generated auth.json file.
+    """
+    credentials = f"$oauthtoken:{token}"
+    encoded = base64.b64encode(credentials.encode()).decode()
+
+    auth_data = {
+        "auths": {
+            registry_host: {
+                "auth": encoded,
+            }
+        }
+    }
+
+    path = Path(output_path)
+    path.write_text(json.dumps(auth_data, indent=2))
+
+    logger.info("Generated registry auth file: %s", path.resolve())
+    return str(path.resolve())

--- a/src/image_collector.py
+++ b/src/image_collector.py
@@ -25,7 +25,6 @@ from types import SimpleNamespace
 import pandas as pd
 from kubernetes.client.rest import ApiException
 
-from .image_analyzer import ImageAnalysisResult, ImageAnalyzer
 from .openshift_client import OpenShiftClient
 
 # Default namespace patterns to exclude (infrastructure namespaces)
@@ -38,12 +37,15 @@ class ContainerImageInfo:
     def __init__(
         self, container_name: str, image_name: str, namespace: str, image_id: str, object_type: str, object_name: str
     ):
+        self.source: str = "openshift"
         self.container_name = container_name
         self.image_name = image_name
         self.namespace = namespace
         self.image_id = image_id
         self.object_type = object_type
         self.object_name = object_name
+        self.registry_org: str = ""
+        self.registry_repo: str = ""
 
         # Analysis results (populated by ImageAnalyzer)
         self.java_binary: str = ""
@@ -60,10 +62,13 @@ class ContainerImageInfo:
     def to_dict(self) -> dict[str, str]:
         """Convert to dictionary for DataFrame creation."""
         return {
+            "source": self.source,
             "container_name": self.container_name,
             "namespace": self.namespace,
             "object_type": self.object_type,
             "object_name": self.object_name,
+            "registry_org": self.registry_org,
+            "registry_repo": self.registry_repo,
             "image_name": self.image_name,
             "image_id": self.image_id,
             "java_binary": self.java_binary,
@@ -836,12 +841,14 @@ class ImageCollector:
         Returns:
             DataFrame with image information.
         """
-        # Define column order (image_name and image_id, then analysis results)
         columns = [
+            "source",
             "container_name",
             "namespace",
             "object_type",
             "object_name",
+            "registry_org",
+            "registry_repo",
             "image_name",
             "image_id",
             "java_binary",
@@ -898,142 +905,3 @@ class ImageCollector:
         """
         df = self.to_dataframe()
         return df.drop_duplicates(subset=["image_name"]).reset_index(drop=True)
-
-    def analyze_images(
-        self,
-        rootfs_path: str,
-        pull_secret_path: str | None = None,
-        debug: bool = False,
-        cluster_name: str | None = None,
-        output_dir: str = "output",
-        logger: logging.Logger | None = None,
-        internal_registry_route: str | None = None,
-        openshift_token: str | None = None,
-    ) -> tuple:
-        """
-        Analyze all collected images for Java, NodeJS, and .NET binaries.
-
-        This method:
-        1. Gets unique images to avoid re-analyzing the same image
-        2. For each unique image, exports and analyzes the container
-        3. Updates all ContainerImageInfo objects with the analysis results
-        4. Saves CSV after each image (for resumability if interrupted)
-        5. Cleans up after each image to save disk space
-
-        Args:
-            rootfs_path: Path where rootfs directory exists
-            pull_secret_path: Path to pull-secret for authentication
-            debug: Enable debug output
-            cluster_name: Cluster name for CSV filename (if provided, saves after each image)
-            output_dir: Directory to save CSV output
-            logger: Optional logger instance for file logging
-            internal_registry_route: External hostname for the OpenShift internal
-                registry. Images referencing the cluster-internal service address
-                are rewritten to use this route for pulling.
-            openshift_token: Bearer token for authenticating to the internal
-                registry route.
-
-        Returns:
-            Tuple of (number of images analyzed, CSV filepath or None)
-        """
-        print("\n🔬 Analyzing images for Java, NodeJS, and .NET binaries...")
-        print("  (Each image will be pulled, analyzed, and cleaned up)")
-        if cluster_name:
-            print("  (CSV will be saved after each image for resumability)")
-
-        if logger:
-            logger.info("Starting image analysis for Java, NodeJS, and .NET binaries")
-
-        # Create analyzer
-        analyzer = ImageAnalyzer(rootfs_path, pull_secret_path, internal_registry_route, openshift_token)
-
-        if debug:
-            print(f"  [DEBUG] Analyzer rootfs_base: {analyzer.rootfs_base}")
-            print(f"  [DEBUG] Analyzer rootfs_path: {analyzer.rootfs_path}")
-
-        # Get unique images
-        unique_images = set()
-        for img in self.images:
-            # Use image_name as key (image_id might be empty for non-Pod objects)
-            unique_images.add(img.image_name)
-
-        print(f"  Found {len(unique_images)} unique images to analyze")
-
-        # Generate CSV filename once (fixed for this run)
-        csv_filepath = None
-        if cluster_name:
-            output_path = Path(output_dir)
-            output_path.mkdir(parents=True, exist_ok=True)
-            timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-            filename = f"{cluster_name}-{timestamp}.csv"
-            csv_filepath = output_path / filename
-
-        # Analyze each unique image
-        analyzed_count = 0
-        results_cache: dict[str, ImageAnalysisResult] = {}
-
-        for idx, image_name in enumerate(unique_images, 1):
-            print(f"\n  [{idx}/{len(unique_images)}] Analyzing: {image_name[:70]}...")
-            if logger:
-                logger.info(f"[{idx}/{len(unique_images)}] Analyzing image: {image_name}")
-
-            try:
-                result = analyzer.analyze_image(image_name, debug=debug)
-                results_cache[image_name] = result
-                analyzed_count += 1
-
-                if logger:
-                    logger.info(
-                        f"  Image analysis completed: java={result.java_found}, node={result.node_found}, dotnet={result.dotnet_found}"
-                    )
-
-            except Exception as e:
-                print(f"    Error analyzing image: {e}")
-                if logger:
-                    logger.error(f"  Error analyzing image {image_name}: {e}")
-                import traceback
-
-                if debug:
-                    traceback.print_exc()
-                    if logger:
-                        logger.exception(f"  Full traceback for {image_name}:")
-                # Create error result
-                results_cache[image_name] = ImageAnalysisResult(image_name=image_name, image_id="", error=str(e))
-
-            # Update all ContainerImageInfo objects with current results
-            for img in self.images:
-                result = results_cache.get(img.image_name)
-                if result:
-                    img.java_binary = result.java_found
-                    img.java_version = result.java_versions
-                    img.java_compatible = result.java_compatible
-                    img.node_binary = result.node_found
-                    img.node_version = result.node_versions
-                    img.node_compatible = result.node_compatible
-                    img.dotnet_binary = result.dotnet_found
-                    img.dotnet_version = result.dotnet_versions
-                    img.dotnet_compatible = result.dotnet_compatible
-                    img.analysis_error = result.error or ""
-
-            # Save CSV after each image analysis (only analyzed images for efficiency)
-            if csv_filepath:
-                # Filter to only include containers whose images have been analyzed
-                analyzed_image_names = set(results_cache.keys())
-                df = self.to_dataframe()
-                df_analyzed = df[df["image_name"].isin(analyzed_image_names)]
-                df_analyzed.to_csv(csv_filepath, index=False)
-                print(f"    💾 Progress saved: {len(df_analyzed)} rows ({idx}/{len(unique_images)} images)")
-
-        print(f"\n✓ Analyzed {analyzed_count} unique images")
-        if logger:
-            logger.info(f"Image analysis completed: {analyzed_count} unique images analyzed")
-
-        # Final save with ALL rows (now all images are analyzed)
-        if csv_filepath:
-            df = self.to_dataframe()
-            df.to_csv(csv_filepath, index=False)
-            print(f"  Final CSV saved to: {csv_filepath} ({len(df)} rows)")
-            if logger:
-                logger.info(f"Final CSV saved to: {csv_filepath} ({len(df)} rows)")
-
-        return analyzed_count, str(csv_filepath) if csv_filepath else None

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -1,0 +1,377 @@
+"""Tests for the AnalysisOrchestrator module."""
+
+import csv
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.analysis_orchestrator import AnalysisOrchestrator
+from src.image_analyzer import BinaryInfo, ImageAnalysisResult
+from src.registry_collector import CSV_COLUMNS
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_analyzer():
+    """Create a mock ImageAnalyzer."""
+    with patch("src.analysis_orchestrator.ImageAnalyzer") as mock_cls:
+        analyzer_instance = MagicMock()
+        mock_cls.return_value = analyzer_instance
+        yield analyzer_instance
+
+
+@pytest.fixture
+def orchestrator():
+    """Create an AnalysisOrchestrator."""
+    return AnalysisOrchestrator(
+        rootfs_path="/tmp/rootfs",
+        pull_secret_path=".pull-secret",
+    )
+
+
+@pytest.fixture
+def sample_images():
+    """Sample image records in unified schema."""
+    return [
+        {
+            "source": "registry",
+            "container_name": "",
+            "namespace": "",
+            "object_type": "",
+            "object_name": "",
+            "registry_org": "testorg",
+            "registry_repo": "java-app",
+            "image_name": "quay.example.com/testorg/java-app:17",
+            "image_id": "",
+        },
+        {
+            "source": "registry",
+            "container_name": "",
+            "namespace": "",
+            "object_type": "",
+            "object_name": "",
+            "registry_org": "testorg",
+            "registry_repo": "node-app",
+            "image_name": "quay.example.com/testorg/node-app:20",
+            "image_id": "",
+        },
+        {
+            "source": "registry",
+            "container_name": "",
+            "namespace": "",
+            "object_type": "",
+            "object_name": "",
+            "registry_org": "testorg",
+            "registry_repo": "java-app",
+            "image_name": "quay.example.com/testorg/java-app:17",
+            "image_id": "",
+        },
+    ]
+
+
+def _make_java_result(image_name: str) -> ImageAnalysisResult:
+    """Build a result with one compatible Java binary."""
+    result = ImageAnalysisResult(image_name=image_name, image_id="")
+    result.java_binaries.append(
+        BinaryInfo(
+            path="/usr/bin/java",
+            version="17.0.1",
+            version_output="openjdk 17.0.1",
+            is_compatible=True,
+            runtime_type="OpenJDK",
+        )
+    )
+    return result
+
+
+def _make_node_result(image_name: str) -> ImageAnalysisResult:
+    """Build a result with one compatible Node binary."""
+    result = ImageAnalysisResult(image_name=image_name, image_id="")
+    result.node_binaries.append(
+        BinaryInfo(
+            path="/usr/local/bin/node",
+            version="20.3.0",
+            version_output="v20.3.0",
+            is_compatible=True,
+            runtime_type="NodeJS",
+        )
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# TestAnalysisOrchestratorAnalyze
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisOrchestratorAnalyze:
+    """Test the analyze_images method."""
+
+    def test_deduplication(self, orchestrator, mock_analyzer, sample_images):
+        """3 records with 2 unique image_names -> analyze called 2 times."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        count, _ = orchestrator.analyze_images(sample_images)
+
+        assert mock_analyzer.analyze_image.call_count == 2
+        assert count == 2
+
+    def test_results_applied_to_all_matching_records(self, orchestrator, mock_analyzer, sample_images):
+        """Both records sharing java-app:17 should get analysis results."""
+        java_result = _make_java_result("quay.example.com/testorg/java-app:17")
+        node_result = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        def side_effect(image_name, debug=False):
+            if "java-app" in image_name:
+                return java_result
+            return node_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator.analyze_images(sample_images)
+
+        java_records = [r for r in sample_images if r["image_name"] == "quay.example.com/testorg/java-app:17"]
+        assert len(java_records) == 2
+        for rec in java_records:
+            assert rec["java_binary"] == "/usr/bin/java"
+            assert rec["java_version"] == "17.0.1"
+            assert rec["java_cgroup_v2_compatible"] == "Yes"
+
+    def test_result_mapping_keys(self, orchestrator, mock_analyzer, sample_images):
+        """Verify all unified schema analysis keys are populated."""
+        java_result = _make_java_result("quay.example.com/testorg/java-app:17")
+        node_result = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        def side_effect(image_name, debug=False):
+            if "java-app" in image_name:
+                return java_result
+            return node_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator.analyze_images(sample_images)
+
+        analysis_keys = [
+            "java_binary",
+            "java_version",
+            "java_cgroup_v2_compatible",
+            "node_binary",
+            "node_version",
+            "node_cgroup_v2_compatible",
+            "dotnet_binary",
+            "dotnet_version",
+            "dotnet_cgroup_v2_compatible",
+            "analysis_error",
+        ]
+        for rec in sample_images:
+            for key in analysis_keys:
+                assert key in rec
+
+    def test_error_handling(self, orchestrator, mock_analyzer, sample_images):
+        """Exception for one image is captured; other image still analyzed."""
+        node_result = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        def side_effect(image_name, debug=False):
+            if "java-app" in image_name:
+                raise RuntimeError("pull failed")
+            return node_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        count, _ = orchestrator.analyze_images(sample_images)
+
+        assert count == 1
+
+        java_records = [r for r in sample_images if r["image_name"] == "quay.example.com/testorg/java-app:17"]
+        for rec in java_records:
+            assert rec["analysis_error"] == "pull failed"
+
+        node_records = [r for r in sample_images if r["image_name"] == "quay.example.com/testorg/node-app:20"]
+        assert node_records[0]["node_binary"] == "/usr/local/bin/node"
+
+    def test_images_mutated_in_place(self, orchestrator, mock_analyzer, sample_images):
+        """Caller's list is mutated; no new list returned."""
+        mock_analyzer.analyze_image.return_value = _make_java_result("x")
+
+        original_id = id(sample_images)
+        orchestrator.analyze_images(sample_images)
+
+        assert id(sample_images) == original_id
+        assert "java_binary" in sample_images[0]
+
+    def test_returns_count_and_filepath(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        """Returns (analyzed_count, csv_filepath)."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+        csv_path = str(tmp_path / "results.csv")
+
+        count, returned_path = orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        assert count == 2
+        assert returned_path == csv_path
+
+    def test_returns_none_filepath_when_not_given(self, orchestrator, mock_analyzer, sample_images):
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        count, returned_path = orchestrator.analyze_images(sample_images)
+
+        assert count == 2
+        assert returned_path is None
+
+
+# ---------------------------------------------------------------------------
+# TestAnalysisOrchestratorCSV
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisOrchestratorCSV:
+    """Test incremental CSV writing."""
+
+    def test_csv_written_after_each_image(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        """CSV file exists after analysis completes."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+        csv_path = str(tmp_path / "results.csv")
+
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        assert (tmp_path / "results.csv").exists()
+
+    def test_csv_header_matches_unified_schema(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+        csv_path = str(tmp_path / "results.csv")
+
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            header = next(reader)
+        assert header == CSV_COLUMNS
+
+    def test_csv_row_count_includes_all_records(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        """CSV has ALL records, not just unique ones."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+        csv_path = str(tmp_path / "results.csv")
+
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            next(reader)
+            rows = list(reader)
+        assert len(rows) == 3
+
+    def test_csv_has_analysis_results(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        java_result = _make_java_result("quay.example.com/testorg/java-app:17")
+        node_result = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        def side_effect(image_name, debug=False):
+            if "java-app" in image_name:
+                return java_result
+            return node_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+        csv_path = str(tmp_path / "results.csv")
+
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        java_rows = [r for r in rows if "java-app" in r["image_name"]]
+        assert len(java_rows) == 2
+        for r in java_rows:
+            assert r["java_binary"] == "/usr/bin/java"
+
+    def test_csv_not_written_when_filepath_is_none(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        _count, filepath = orchestrator.analyze_images(sample_images)
+
+        assert filepath is None
+
+    def test_csv_uses_csv_columns(self, orchestrator, mock_analyzer, sample_images, tmp_path):
+        """Verify the CSV columns come from registry_collector.CSV_COLUMNS."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+        csv_path = str(tmp_path / "results.csv")
+
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames
+        assert list(fieldnames) == CSV_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# TestAnalysisOrchestratorOpenShift
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisOrchestratorOpenShift:
+    """Test with OpenShift-mode image records."""
+
+    def test_works_with_openshift_source(self, mock_analyzer):
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            internal_registry_route="registry.apps.example.com",
+            openshift_token="sha256~token123",
+        )
+        images = [
+            {
+                "source": "openshift",
+                "container_name": "app",
+                "namespace": "my-ns",
+                "object_type": "Deployment",
+                "object_name": "my-deploy",
+                "registry_org": "",
+                "registry_repo": "",
+                "image_name": "quay.io/my-org/my-image:latest",
+                "image_id": "sha256:abc123",
+            },
+        ]
+        mock_analyzer.analyze_image.return_value = _make_java_result("quay.io/my-org/my-image:latest")
+
+        count, _ = orchestrator.analyze_images(images)
+
+        assert count == 1
+        assert images[0]["java_binary"] == "/usr/bin/java"
+
+    def test_internal_registry_route_passed_to_analyzer(self):
+        with patch("src.analysis_orchestrator.ImageAnalyzer") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+            mock_cls.return_value = mock_instance
+
+            orchestrator = AnalysisOrchestrator(
+                rootfs_path="/tmp/rootfs",
+                internal_registry_route="registry.apps.example.com",
+                openshift_token="sha256~token123",
+            )
+            orchestrator.analyze_images([{"image_name": "quay.io/test:latest"}])
+
+            mock_cls.assert_called_once_with(
+                "/tmp/rootfs",
+                None,
+                "registry.apps.example.com",
+                "sha256~token123",
+            )
+
+    def test_openshift_token_passed_to_analyzer(self):
+        with patch("src.analysis_orchestrator.ImageAnalyzer") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+            mock_cls.return_value = mock_instance
+
+            orchestrator = AnalysisOrchestrator(
+                rootfs_path="/tmp/rootfs",
+                pull_secret_path=".pull-secret",
+                openshift_token="sha256~mytoken",
+            )
+            orchestrator.analyze_images([{"image_name": "quay.io/test:latest"}])
+
+            args = mock_cls.call_args[0]
+            assert args[3] == "sha256~mytoken"

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,68 @@
+"""Tests for the auth_utils module."""
+
+import base64
+import json
+
+from src.auth_utils import generate_registry_auth_json
+
+# ---------------------------------------------------------------------------
+# TestGenerateRegistryAuthJson
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateRegistryAuthJson:
+    """Test generate_registry_auth_json."""
+
+    def test_generates_valid_json(self, tmp_path):
+        output = tmp_path / "auth.json"
+        generate_registry_auth_json("quay.example.com", "mytoken", str(output))
+
+        data = json.loads(output.read_text())
+        assert "auths" in data
+        assert "quay.example.com" in data["auths"]
+
+    def test_auth_is_base64_oauthtoken(self, tmp_path):
+        output = tmp_path / "auth.json"
+        generate_registry_auth_json("quay.example.com", "secret123", str(output))
+
+        data = json.loads(output.read_text())
+        encoded = data["auths"]["quay.example.com"]["auth"]
+        decoded = base64.b64decode(encoded).decode()
+        assert decoded == "$oauthtoken:secret123"
+
+    def test_registry_host_used_as_key(self, tmp_path):
+        output = tmp_path / "auth.json"
+        generate_registry_auth_json("my-registry.io", "tok", str(output))
+
+        data = json.loads(output.read_text())
+        assert "my-registry.io" in data["auths"]
+
+    def test_file_created_at_output_path(self, tmp_path):
+        output = tmp_path / "custom-auth.json"
+        generate_registry_auth_json("quay.io", "tok", str(output))
+        assert output.exists()
+
+    def test_returns_absolute_path(self, tmp_path):
+        output = tmp_path / "auth.json"
+        result = generate_registry_auth_json("quay.io", "tok", str(output))
+        assert result == str(output.resolve())
+
+    def test_overwrites_existing_file(self, tmp_path):
+        output = tmp_path / "auth.json"
+        output.write_text("old content")
+
+        generate_registry_auth_json("quay.io", "newtok", str(output))
+
+        data = json.loads(output.read_text())
+        decoded = base64.b64decode(data["auths"]["quay.io"]["auth"]).decode()
+        assert decoded == "$oauthtoken:newtok"
+
+    def test_json_structure(self, tmp_path):
+        output = tmp_path / "auth.json"
+        generate_registry_auth_json("quay.example.com", "tok", str(output))
+
+        data = json.loads(output.read_text())
+        assert isinstance(data, dict)
+        assert isinstance(data["auths"], dict)
+        assert isinstance(data["auths"]["quay.example.com"], dict)
+        assert "auth" in data["auths"]["quay.example.com"]

--- a/tests/test_image_collector.py
+++ b/tests/test_image_collector.py
@@ -147,12 +147,15 @@ class TestContainerImageInfo:
             object_name="my-deployment",
         )
         d = info.to_dict()
+        assert d["source"] == "openshift"
         assert d["container_name"] == "app"
         assert d["image_name"] == "quay.io/my-org/my-image:latest"
         assert d["namespace"] == "my-app"
         assert d["image_id"] == "sha256:abc123"
         assert d["object_type"] == "Deployment"
         assert d["object_name"] == "my-deployment"
+        assert d["registry_org"] == ""
+        assert d["registry_repo"] == ""
         assert d["java_binary"] == ""
         assert d["java_version"] == ""
         assert d["java_cgroup_v2_compatible"] == ""
@@ -171,6 +174,9 @@ class TestContainerImageInfo:
         info.java_version = "17.0.1"
         info.java_compatible = "Yes"
         d = info.to_dict()
+        assert d["source"] == "openshift"
+        assert d["registry_org"] == ""
+        assert d["registry_repo"] == ""
         assert d["java_binary"] == "/usr/bin/java"
         assert d["java_version"] == "17.0.1"
         assert d["java_cgroup_v2_compatible"] == "Yes"


### PR DESCRIPTION
Extract analyze_images() from ImageCollector into a source-agnostic AnalysisOrchestrator that works with plain dicts (unified schema), enabling analysis of both OpenShift and registry image sources.
- Add source, registry_org, registry_repo fields to ContainerImageInfo and align to_dict()/to_dataframe() with registry_collector.CSV_COLUMNS
- Remove analyze_images() from ImageCollector (moved to orchestrator)
- Create AnalysisOrchestrator with incremental CSV saving, deduplication by image_name, and per-image error resilience
- Create auth_utils with generate_registry_auth_json() for podman auth
- Add tests for orchestrator and auth_utils; update existing tests