### PR TITLE
Fix registry mode using stale .pull-secret instead of --registry-token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ env/
 .env
 
 # OpenShift pull secret (sensitive data)
-.pull-secret
+.pull-secret*
 
 # Python cache
 __pycache__/

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -505,9 +505,12 @@ def main() -> int:
                         logger.error("--analyze requires --rootfs-path")
                     return 1
 
-                pull_secret_path = None
-                if args.pull_secret and Path(args.pull_secret).exists():
+                pull_secret_explicitly_set = args.pull_secret != ".pull-secret"
+                if pull_secret_explicitly_set and Path(args.pull_secret).exists():
                     pull_secret_path = args.pull_secret
+                    print(f"🔑 Using pull-secret: {pull_secret_path}")
+                    if log_to_file:
+                        logger.info(f"Using pull-secret: {pull_secret_path}")
                 else:
                     pull_secret_path = generate_registry_auth_json(
                         registry_host=registry_host,


### PR DESCRIPTION
In registry mode the default --pull-secret value (".pull-secret") was picked up when the file existed on disk, causing podman to authenticate with stale OpenShift credentials instead of the registry token. Now the existing pull-secret is only honoured when --pull-secret is explicitly passed; otherwise generate_registry_auth_json() is always called.