### PR TITLE
Handle unknown runtime versions: return "Unknown" compatibility inste…

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,8 @@ oc apply -f manifests/cluster/registry-default-route.yaml
 #   🔬 Analysis Results:
 #      Java found in: 45 containers
 #        ✓ cgroup v2 compatible: 30
-#        ✗ cgroup v2 incompatible: 15
+#        ✗ cgroup v2 incompatible: 12
+#        ? cgroup v2 unknown: 3
 #      Node.js found in: 12 containers
 #        ✓ cgroup v2 compatible: 10
 #        ✗ cgroup v2 incompatible: 2
@@ -567,13 +568,13 @@ The tool generates a CSV file in the `output` directory (or the path specified b
 | `image_id` | Full image ID when available (both modes) |
 | `java_binary` | Path to Java binary found (or "None") |
 | `java_version` | Java version detected |
-| `java_cgroup_v2_compatible` | "Yes", "No", or "N/A" |
+| `java_cgroup_v2_compatible` | "Yes", "No", "Unknown", or "N/A" |
 | `node_binary` | Path to Node.js binary found (or "None") |
 | `node_version` | Node.js version detected |
-| `node_cgroup_v2_compatible` | "Yes", "No", or "N/A" |
+| `node_cgroup_v2_compatible` | "Yes", "No", "Unknown", or "N/A" |
 | `dotnet_binary` | Path to .NET binary found (or "None") |
 | `dotnet_version` | .NET version detected |
-| `dotnet_cgroup_v2_compatible` | "Yes", "No", or "N/A" |
+| `dotnet_cgroup_v2_compatible` | "Yes", "No", "Unknown", or "N/A" |
 | `analysis_error` | Error message if analysis failed |
 
 ### Identifying Incompatible Images
@@ -587,6 +588,7 @@ The fields that indicate cgroups v2 incompatibility are:
 Possible values for these fields:
 - `Yes` - The runtime is compatible with cgroup v2
 - `No` - The runtime is **NOT** compatible with cgroup v2 and requires an upgrade
+- `Unknown` - The runtime was found but its version could not be determined (e.g. the binary failed to execute inside the container)
 - `N/A` - The runtime was not found in the image
 
 ### Filename Format

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -26,7 +26,7 @@ class BinaryInfo:
     path: str
     version: str
     version_output: str
-    is_compatible: bool
+    is_compatible: bool | None  # None = version unknown, cannot determine
     runtime_type: str  # OpenJDK, IBM Semeru, IBM Java, NodeJS, etc.
 
 
@@ -60,6 +60,8 @@ class ImageAnalysisResult:
         """Return compatibility status for Java."""
         if not self.java_binaries:
             return "N/A"
+        if any(b.is_compatible is None for b in self.java_binaries):
+            return "Unknown"
         compatible = all(b.is_compatible for b in self.java_binaries)
         return "Yes" if compatible else "No"
 
@@ -82,6 +84,8 @@ class ImageAnalysisResult:
         """Return compatibility status for Node."""
         if not self.node_binaries:
             return "N/A"
+        if any(b.is_compatible is None for b in self.node_binaries):
+            return "Unknown"
         compatible = all(b.is_compatible for b in self.node_binaries)
         return "Yes" if compatible else "No"
 
@@ -104,6 +108,8 @@ class ImageAnalysisResult:
         """Return compatibility status for .NET."""
         if not self.dotnet_binaries:
             return "N/A"
+        if any(b.is_compatible is None for b in self.dotnet_binaries):
+            return "Unknown"
         compatible = all(b.is_compatible for b in self.dotnet_binaries)
         return "Yes" if compatible else "No"
 
@@ -582,6 +588,7 @@ class ImageAnalyzer:
                 "podman",
                 "run",
                 "--rm",
+                "--no-healthcheck",
                 "--entrypoint",
                 binary_path,
                 "--privileged",
@@ -648,6 +655,7 @@ class ImageAnalyzer:
                 "podman",
                 "run",
                 "--rm",
+                "--no-healthcheck",
                 "--entrypoint",
                 binary_path,
                 "--privileged",
@@ -679,7 +687,7 @@ class ImageAnalyzer:
 
         return "unknown", output
 
-    def _check_java_compatibility(self, version: str, runtime_type: str) -> bool:
+    def _check_java_compatibility(self, version: str, runtime_type: str) -> bool | None:
         """
         Check if Java version is compatible with cgroup v2.
 
@@ -693,8 +701,10 @@ class ImageAnalyzer:
             runtime_type: Type of Java runtime
 
         Returns:
-            True if compatible
+            True if compatible, False if not, None if version is unknown
         """
+        if version == "unknown":
+            return None
         try:
             # Parse version - handle formats like 1.8.0_372, 11.0.16, 17.0.4.0
             version = version.replace("-b", ".").replace("_", ".")
@@ -755,7 +765,7 @@ class ImageAnalyzer:
         except Exception:
             return False
 
-    def _check_node_compatibility(self, version: str) -> bool:
+    def _check_node_compatibility(self, version: str) -> bool | None:
         """
         Check if Node.js version is compatible with cgroup v2.
 
@@ -765,8 +775,10 @@ class ImageAnalyzer:
             version: Node.js version string
 
         Returns:
-            True if compatible
+            True if compatible, False if not, None if version is unknown
         """
+        if version == "unknown":
+            return None
         try:
             parts = [int(p) for p in version.split(".")]
 
@@ -812,6 +824,7 @@ class ImageAnalyzer:
                 "podman",
                 "run",
                 "--rm",
+                "--no-healthcheck",
                 "--entrypoint",
                 binary_path,
                 "--privileged",
@@ -843,7 +856,7 @@ class ImageAnalyzer:
 
         return "unknown", output
 
-    def _check_dotnet_compatibility(self, version: str) -> bool:
+    def _check_dotnet_compatibility(self, version: str) -> bool | None:
         """
         Check if .NET version is compatible with cgroup v2.
 
@@ -855,8 +868,10 @@ class ImageAnalyzer:
             version: .NET version string (e.g., "8.0.122", "3.0.100")
 
         Returns:
-            True if compatible (version >= 5.0)
+            True if compatible (version >= 5.0), False if not, None if version is unknown
         """
+        if version == "unknown":
+            return None
         try:
             parts = [int(p) for p in version.split(".")]
 
@@ -1100,17 +1115,17 @@ class ImageAnalyzer:
             # Report findings
             if result.java_binaries:
                 for b in result.java_binaries:
-                    compat = "✓" if b.is_compatible else "✗"
+                    compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
                     print(f"      {compat} Java ({b.runtime_type}): {b.version} at {b.path}")
 
             if result.node_binaries:
                 for b in result.node_binaries:
-                    compat = "✓" if b.is_compatible else "✗"
+                    compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
                     print(f"      {compat} Node.js: {b.version} at {b.path}")
 
             if result.dotnet_binaries:
                 for b in result.dotnet_binaries:
-                    compat = "✓" if b.is_compatible else "✗"
+                    compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
                     print(f"      {compat} .NET: {b.version} at {b.path}")
 
             if not result.java_binaries and not result.node_binaries and not result.dotnet_binaries:

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -158,7 +158,7 @@ class TestJavaCompatibility:
     # --- Edge cases ---
 
     def test_unknown_version(self, analyzer):
-        assert analyzer._check_java_compatibility("unknown", "OpenJDK") is False
+        assert analyzer._check_java_compatibility("unknown", "OpenJDK") is None
 
     def test_empty_version(self, analyzer):
         assert analyzer._check_java_compatibility("", "OpenJDK") is False
@@ -205,7 +205,7 @@ class TestNodeCompatibility:
         assert analyzer._check_node_compatibility(version) is False
 
     def test_unknown_version(self, analyzer):
-        assert analyzer._check_node_compatibility("unknown") is False
+        assert analyzer._check_node_compatibility("unknown") is None
 
     def test_empty_version(self, analyzer):
         assert analyzer._check_node_compatibility("") is False
@@ -255,7 +255,7 @@ class TestDotnetCompatibility:
         assert analyzer._check_dotnet_compatibility(version) is False
 
     def test_unknown_version(self, analyzer):
-        assert analyzer._check_dotnet_compatibility("unknown") is False
+        assert analyzer._check_dotnet_compatibility("unknown") is None
 
     def test_empty_version(self, analyzer):
         assert analyzer._check_dotnet_compatibility("") is False
@@ -530,6 +530,67 @@ class TestImageAnalysisResult:
             )
         )
         assert result.java_compatible == "No"
+
+    def test_java_unknown_version(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc123")
+        result.java_binaries.append(
+            BinaryInfo(
+                path="/usr/bin/java",
+                version="unknown",
+                version_output="",
+                is_compatible=None,
+                runtime_type="Unknown",
+            )
+        )
+        assert result.java_compatible == "Unknown"
+
+    def test_java_mixed_known_and_unknown(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc123")
+        result.java_binaries.append(
+            BinaryInfo(
+                path="/usr/bin/java",
+                version="17.0.1",
+                version_output="",
+                is_compatible=True,
+                runtime_type="OpenJDK",
+            )
+        )
+        result.java_binaries.append(
+            BinaryInfo(
+                path="/opt/java/bin/java",
+                version="unknown",
+                version_output="",
+                is_compatible=None,
+                runtime_type="Unknown",
+            )
+        )
+        assert result.java_compatible == "Unknown"
+
+    def test_node_unknown_version(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="")
+        result.node_binaries.append(
+            BinaryInfo(
+                path="/usr/local/bin/node",
+                version="unknown",
+                version_output="",
+                is_compatible=None,
+                runtime_type="NodeJS",
+            )
+        )
+        assert result.node_compatible == "Unknown"
+
+    def test_dotnet_unknown_version(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="")
+        result.dotnet_binaries.append(
+            BinaryInfo(
+                path="/usr/share/dotnet/dotnet",
+                version="unknown",
+                version_output="",
+                is_compatible=None,
+                runtime_type=".NET",
+            )
+        )
+        assert result.dotnet_compatible == "Unknown"
 
     def test_node_result(self):
         result = ImageAnalysisResult(image_name="test:latest", image_id="")


### PR DESCRIPTION
…ad of "No"

When a runtime binary (Java, Node.js, .NET) is found but its version cannot be determined (e.g. podman run fails due to healthcheck/systemd issues), the cgroup v2 compatibility column now reports "Unknown" instead of incorrectly reporting "No".
Changes:
- BinaryInfo.is_compatible changed from bool to bool | None
- Compatibility check methods return None for "unknown" versions
- Compatibility properties return "Unknown" when any binary has undetermined version
- Added --no-healthcheck to all podman run commands to prevent failures on images with HEALTHCHECK directives in environments without a systemd user session
- Updated tests and README accordingly