### PR TITLE
Exclude node_modules from binary scan and add "Unknown" count to summ…

### DIFF
--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -349,24 +349,33 @@ def _print_analysis_summary(images: list[dict]) -> None:
     dotnet_found = sum(1 for img in images if img.get("dotnet_binary", "None") != "None")
     java_compat = sum(1 for img in images if img.get("java_cgroup_v2_compatible") == "Yes")
     java_incompat = sum(1 for img in images if img.get("java_cgroup_v2_compatible") == "No")
+    java_unknown = sum(1 for img in images if img.get("java_cgroup_v2_compatible") == "Unknown")
     node_compat = sum(1 for img in images if img.get("node_cgroup_v2_compatible") == "Yes")
     node_incompat = sum(1 for img in images if img.get("node_cgroup_v2_compatible") == "No")
+    node_unknown = sum(1 for img in images if img.get("node_cgroup_v2_compatible") == "Unknown")
     dotnet_compat = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "Yes")
     dotnet_incompat = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "No")
+    dotnet_unknown = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "Unknown")
 
     print("\n   🔬 Analysis Results:")
     print(f"      Java found in: {java_found} containers")
     if java_found > 0:
         print(f"        ✓ cgroup v2 compatible: {java_compat}")
         print(f"        ✗ cgroup v2 incompatible: {java_incompat}")
+        if java_unknown > 0:
+            print(f"        ? cgroup v2 unknown: {java_unknown}")
     print(f"      Node.js found in: {node_found} containers")
     if node_found > 0:
         print(f"        ✓ cgroup v2 compatible: {node_compat}")
         print(f"        ✗ cgroup v2 incompatible: {node_incompat}")
+        if node_unknown > 0:
+            print(f"        ? cgroup v2 unknown: {node_unknown}")
     print(f"      .NET found in: {dotnet_found} containers")
     if dotnet_found > 0:
         print(f"        ✓ cgroup v2 compatible: {dotnet_compat}")
         print(f"        ✗ cgroup v2 incompatible: {dotnet_incompat}")
+        if dotnet_unknown > 0:
+            print(f"        ? cgroup v2 unknown: {dotnet_unknown}")
 
 
 def main() -> int:

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -136,6 +136,7 @@ class ImageAnalyzer:
     # Paths to exclude - patterns that path must NOT contain
     EXCLUDE_PATH_CONTAINS = [
         "/.dotnet/optimizationdata/",  # .NET optimization data files (not binaries)
+        "/node_modules/",  # npm packages (not actual runtime binaries)
     ]
 
     def _is_excluded_path(self, path: str) -> bool:

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -693,6 +693,27 @@ class TestPrintAnalysisSummary:
         assert "Node.js found in: 1 containers" in out
         assert "incompatible: 1" in out
 
+    def test_counts_unknown(self, capsys):
+        images = [
+            {"java_binary": "/usr/bin/java", "java_cgroup_v2_compatible": "Yes"},
+            {"java_binary": "/usr/bin/java", "java_cgroup_v2_compatible": "Unknown"},
+            {"node_binary": "/usr/bin/node", "node_cgroup_v2_compatible": "Unknown"},
+        ]
+        _print_analysis_summary(images)
+        out = capsys.readouterr().out
+        assert "Java found in: 2 containers" in out
+        assert "compatible: 1" in out
+        assert "? cgroup v2 unknown: 1" in out
+        assert "Node.js found in: 1 containers" in out
+
+    def test_unknown_not_shown_when_zero(self, capsys):
+        images = [
+            {"java_binary": "/usr/bin/java", "java_cgroup_v2_compatible": "Yes"},
+        ]
+        _print_analysis_summary(images)
+        out = capsys.readouterr().out
+        assert "unknown" not in out
+
 
 # ---------------------------------------------------------------------------
 # TestOpenShiftModeNotBroken

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -435,6 +435,17 @@ class TestPathExclusion:
         path = "/home/user/.dotnet/optimizationdata/some-file"
         assert analyzer._is_excluded_path(path) is True
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/opt/app/node_modules/node/bin/node",
+            "/usr/local/lib/node_modules/node/bin/node",
+            "/opt/myapp/runtime/node_modules/node/bin/node",
+        ],
+    )
+    def test_node_modules_excluded(self, analyzer, path):
+        assert analyzer._is_excluded_path(path) is True
+
 
 # ---------------------------------------------------------------------------
 # ImageAnalysisResult properties


### PR DESCRIPTION
…ary recap

- Add /node_modules/ to EXCLUDE_PATH_CONTAINS so npm-installed node binaries (not actual runtimes) are skipped during analysis
- Add "? cgroup v2 unknown" counter to _print_analysis_summary, shown only when there are undetermined versions
- Update README compatibility values to include "Unknown"