### PR TITLE
Add --image-timeout flag for per-image pull+scan deadline (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ The container runs as root. For image pulls and analysis, podman runs inside the
 # Inspect only a specific namespace
 ./image-cgroupsv2-inspector -n my-namespace
 ./image-cgroupsv2-inspector --namespace my-namespace --analyze --rootfs-path /tmp/images
+
+# Limit each image pull+scan to 120 seconds (default: 600)
+./image-cgroupsv2-inspector --rootfs-path /tmp/images --analyze --image-timeout 120
 ```
 
 #### Getting OpenShift Credentials
@@ -426,6 +429,7 @@ These can also be set in the `.env` file. CLI arguments override environment var
 | `--env-file` | Path to .env file for credentials (default: `.env`) |
 | `--skip-collection` | Skip image collection (useful for testing rootfs setup) |
 | `--skip-disk-check` | Skip the 20GB minimum free disk space check. A warning will be logged instead of stopping execution |
+| `--image-timeout` | Maximum seconds for pulling and scanning each individual image (default: `600`). If an image exceeds this limit it is skipped with a warning and the tool exits with code `2` |
 | `--log-to-file` | Enable logging to file |
 | `--log-file` | Path to log file (default: `image-cgroupsv2-inspector.log`). Implies `--log-to-file` |
 | `-v, --verbose` | Enable verbose output |

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -352,7 +352,7 @@ def setup_rootfs(rootfs_path: str, logger: logging.Logger | None = None, skip_di
     return True
 
 
-def _print_analysis_summary(images: list[dict]) -> None:
+def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None = None) -> None:
     """Print analysis summary from image record dicts."""
     java_found = sum(1 for img in images if img.get("java_binary", "None") != "None")
     node_found = sum(1 for img in images if img.get("node_binary", "None") != "None")
@@ -386,6 +386,8 @@ def _print_analysis_summary(images: list[dict]) -> None:
         print(f"        ✗ cgroup v2 incompatible: {dotnet_incompat}")
         if dotnet_unknown > 0:
             print(f"        ? cgroup v2 unknown: {dotnet_unknown}")
+    skipped_count = len(skipped_images) if skipped_images else 0
+    print(f"      Images skipped (timeout): {skipped_count}")
 
 
 def main() -> int:
@@ -579,7 +581,7 @@ def main() -> int:
             print(f"   Unique images: {unique_count}")
 
             if args.analyze:
-                _print_analysis_summary(images)
+                _print_analysis_summary(images, skipped)
 
             print(f"\n   Output file: {csv_path}")
 
@@ -751,7 +753,7 @@ def main() -> int:
         print(f"   Object types: {df['object_type'].value_counts().to_dict()}")
 
         if args.analyze:
-            _print_analysis_summary(image_dicts)
+            _print_analysis_summary(image_dicts, skipped)
 
         print(f"\n   Output file: {csv_path}")
 

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -245,6 +245,16 @@ The tool will save credentials to .env file after successful connection.
         help="Only scan the N most recent tags per repository",
     )
 
+    # --- Timeout ---
+
+    parser.add_argument(
+        "--image-timeout",
+        dest="image_timeout",
+        type=int,
+        default=600,
+        help="Maximum seconds allowed for pulling and scanning each individual image (default: 600)",
+    )
+
     # --- General arguments ---
 
     parser.add_argument(
@@ -544,8 +554,9 @@ def main() -> int:
                 orchestrator = AnalysisOrchestrator(
                     rootfs_path=rootfs_path,
                     pull_secret_path=pull_secret_path,
+                    image_timeout=args.image_timeout,
                 )
-                _, csv_path = orchestrator.analyze_images(
+                _, csv_path, skipped = orchestrator.analyze_images(
                     images=images,
                     csv_filepath=csv_filepath,
                     debug=args.verbose,
@@ -555,6 +566,7 @@ def main() -> int:
                     logger.info("Image analysis completed")
             else:
                 csv_path = registry_collector.save_to_csv(images, output_dir=args.output_dir)
+                skipped = []
                 if log_to_file:
                     logger.info(f"Results saved to CSV: {csv_path}")
 
@@ -589,7 +601,7 @@ def main() -> int:
             logger.info("=" * 60)
 
         print("\n✓ Done!")
-        return 0
+        return 2 if skipped else 0
 
     # ── OpenShift mode ───────────────────────────────────────────
     try:
@@ -629,6 +641,8 @@ def main() -> int:
         if log_to_file:
             logger.error(f"Connection error: {e}")
         return 1
+
+    skipped: list[str] = []
 
     try:
         # Handle namespace filtering
@@ -705,8 +719,9 @@ def main() -> int:
                 pull_secret_path=pull_secret_path,
                 internal_registry_route=internal_registry_route,
                 openshift_token=client.token,
+                image_timeout=args.image_timeout,
             )
-            _, csv_path = orchestrator.analyze_images(
+            _, csv_path, skipped = orchestrator.analyze_images(
                 images=image_dicts,
                 csv_filepath=csv_filepath,
                 debug=args.verbose,
@@ -716,6 +731,7 @@ def main() -> int:
                 logger.info("Image analysis completed")
         else:
             csv_path = collector.save_to_csv(cluster_name=client.cluster_name, output_dir=args.output_dir)
+            skipped = []
             if log_to_file:
                 logger.info(f"Results saved to CSV: {csv_path}")
 
@@ -768,7 +784,7 @@ def main() -> int:
         logger.info("=" * 60)
 
     print("\n✓ Done!")
-    return 0
+    return 2 if skipped else 0
 
 
 if __name__ == "__main__":

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -120,10 +120,7 @@ class AnalysisOrchestrator:
                 results_cache[image_name] = result
                 analyzed_count += 1
             except _ImageTimeout:
-                print(
-                    f"WARNING: Skipping image {image_name} "
-                    f"— timed out after {self.image_timeout} seconds"
-                )
+                print(f"WARNING: Skipping image {image_name} — timed out after {self.image_timeout} seconds")
                 if logger:
                     logger.warning(
                         "Skipping image %s — timed out after %d seconds",

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -16,8 +16,13 @@ from .registry_collector import CSV_COLUMNS
 logger = logging.getLogger(__name__)
 
 
-class _ImageTimeout(Exception):
-    """Raised when per-image analysis exceeds the configured timeout."""
+class _ImageTimeout(BaseException):
+    """Raised when per-image analysis exceeds the configured timeout.
+
+    Inherits from BaseException (not Exception) so that the signal-raised
+    timeout is not swallowed by the broad ``except Exception`` handlers
+    inside ImageAnalyzer._run_command, _extract_tar, and analyze_image.
+    """
 
 
 class AnalysisOrchestrator:

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -7,12 +7,17 @@ Works with image records from both OpenShift and registry collectors.
 
 import csv
 import logging
+import signal
 import traceback
 
 from .image_analyzer import ImageAnalysisResult, ImageAnalyzer
 from .registry_collector import CSV_COLUMNS
 
 logger = logging.getLogger(__name__)
+
+
+class _ImageTimeout(Exception):
+    """Raised when per-image analysis exceeds the configured timeout."""
 
 
 class AnalysisOrchestrator:
@@ -28,6 +33,8 @@ class AnalysisOrchestrator:
             registry (only for OpenShift mode, None for registry mode).
         openshift_token: Bearer token for internal registry auth
             (only for OpenShift mode, None for registry mode).
+        image_timeout: Maximum seconds for pulling and scanning each
+            individual image.  0 disables the timeout.
     """
 
     def __init__(
@@ -36,11 +43,13 @@ class AnalysisOrchestrator:
         pull_secret_path: str | None = None,
         internal_registry_route: str | None = None,
         openshift_token: str | None = None,
+        image_timeout: int = 600,
     ) -> None:
         self.rootfs_path = rootfs_path
         self.pull_secret_path = pull_secret_path
         self.internal_registry_route = internal_registry_route
         self.openshift_token = openshift_token
+        self.image_timeout = image_timeout
 
     def _save_csv(self, images: list[dict], filepath: str) -> None:
         """Write image records to CSV using the unified schema."""
@@ -57,7 +66,7 @@ class AnalysisOrchestrator:
         csv_filepath: str | None = None,
         debug: bool = False,
         logger: logging.Logger | None = None,
-    ) -> tuple[int, str | None]:
+    ) -> tuple[int, str | None, list[str]]:
         """Analyze images and save CSV incrementally.
 
         For each unique image_name:
@@ -78,7 +87,8 @@ class AnalysisOrchestrator:
             logger: Optional logger for file logging.
 
         Returns:
-            Tuple of (images_analyzed_count, csv_filepath or None).
+            Tuple of (images_analyzed_count, csv_filepath or None,
+            skipped_images list).
         """
         analyzer = ImageAnalyzer(
             self.rootfs_path,
@@ -97,6 +107,7 @@ class AnalysisOrchestrator:
 
         total = len(unique_image_names)
         analyzed_count = 0
+        skipped_images: list[str] = []
         results_cache: dict[str, ImageAnalysisResult] = {}
 
         for idx, image_name in enumerate(unique_image_names, 1):
@@ -105,9 +116,30 @@ class AnalysisOrchestrator:
                 logger.info("[%d/%d] Analyzing image: %s", idx, total, image_name)
 
             try:
-                result = analyzer.analyze_image(image_name, debug=debug)
+                result = self._analyze_with_timeout(analyzer, image_name, debug=debug)
                 results_cache[image_name] = result
                 analyzed_count += 1
+            except _ImageTimeout:
+                print(
+                    f"WARNING: Skipping image {image_name} "
+                    f"— timed out after {self.image_timeout} seconds"
+                )
+                if logger:
+                    logger.warning(
+                        "Skipping image %s — timed out after %d seconds",
+                        image_name,
+                        self.image_timeout,
+                    )
+                skipped_images.append(image_name)
+                analyzer._cleanup(
+                    analyzer._rewrite_internal_registry(image_name),
+                    debug=debug,
+                )
+                results_cache[image_name] = ImageAnalysisResult(
+                    image_name=image_name,
+                    image_id="",
+                    error=f"timed out after {self.image_timeout} seconds",
+                )
             except Exception as exc:
                 print(f"  Error analyzing image: {exc}")
                 if logger:
@@ -128,7 +160,40 @@ class AnalysisOrchestrator:
         if csv_filepath:
             self._save_csv(images, csv_filepath)
 
-        return analyzed_count, csv_filepath
+        if skipped_images:
+            print("\n=== Skipped images (timeout) ===")
+            for name in skipped_images:
+                print(name)
+            print(f"Total skipped: {len(skipped_images)}")
+
+        return analyzed_count, csv_filepath, skipped_images
+
+    def _analyze_with_timeout(
+        self,
+        analyzer: ImageAnalyzer,
+        image_name: str,
+        debug: bool = False,
+    ) -> ImageAnalysisResult:
+        """Run ``analyzer.analyze_image`` with an optional SIGALRM timeout."""
+        if not self.image_timeout:
+            return analyzer.analyze_image(image_name, debug=debug)
+
+        old_handler = signal.getsignal(signal.SIGALRM)
+
+        def _alarm_handler(signum, frame):
+            raise _ImageTimeout()
+
+        try:
+            signal.signal(signal.SIGALRM, _alarm_handler)
+            signal.alarm(self.image_timeout)
+            result = analyzer.analyze_image(image_name, debug=debug)
+            signal.alarm(0)
+            return result
+        except _ImageTimeout:
+            signal.alarm(0)
+            raise
+        finally:
+            signal.signal(signal.SIGALRM, old_handler)
 
     @staticmethod
     def _apply_results(

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -128,10 +128,7 @@ class AnalysisOrchestrator:
                         self.image_timeout,
                     )
                 skipped_images.append(image_name)
-                analyzer._cleanup(
-                    analyzer._rewrite_internal_registry(image_name),
-                    debug=debug,
-                )
+                analyzer.cleanup_image(image_name, debug=debug)
                 results_cache[image_name] = ImageAnalysisResult(
                     image_name=image_name,
                     image_id="",

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -933,6 +933,19 @@ class ImageAnalyzer:
                 print(f"      [DEBUG] Removing image: {image_name[:50]}...")
             self._run_command(["podman", "rmi", "-f", image_name])
 
+    def cleanup_image(self, image_name: str, debug: bool = False) -> None:
+        """
+        Clean up rootfs and remove the pulled image.
+
+        Resolves internal-registry rewrites automatically so the caller
+        only needs to pass the original image name.
+
+        Args:
+            image_name: Original image name (before any registry rewrite).
+            debug: Enable debug output.
+        """
+        self._cleanup(self._rewrite_internal_registry(image_name), debug=debug)
+
     def analyze_image(self, image_name: str, image_id: str = "", debug: bool = False) -> ImageAnalysisResult:
         """
         Analyze a container image for Java and NodeJS binaries.

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -114,7 +114,7 @@ class TestAnalysisOrchestratorAnalyze:
         """3 records with 2 unique image_names -> analyze called 2 times."""
         mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
 
-        count, _ = orchestrator.analyze_images(sample_images)
+        count, _, _skipped = orchestrator.analyze_images(sample_images)
 
         assert mock_analyzer.analyze_image.call_count == 2
         assert count == 2
@@ -181,7 +181,7 @@ class TestAnalysisOrchestratorAnalyze:
 
         mock_analyzer.analyze_image.side_effect = side_effect
 
-        count, _ = orchestrator.analyze_images(sample_images)
+        count, _, _skipped = orchestrator.analyze_images(sample_images)
 
         assert count == 1
 
@@ -203,22 +203,24 @@ class TestAnalysisOrchestratorAnalyze:
         assert "java_binary" in sample_images[0]
 
     def test_returns_count_and_filepath(self, orchestrator, mock_analyzer, sample_images, tmp_path):
-        """Returns (analyzed_count, csv_filepath)."""
+        """Returns (analyzed_count, csv_filepath, skipped)."""
         mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
         csv_path = str(tmp_path / "results.csv")
 
-        count, returned_path = orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+        count, returned_path, skipped = orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
 
         assert count == 2
         assert returned_path == csv_path
+        assert skipped == []
 
     def test_returns_none_filepath_when_not_given(self, orchestrator, mock_analyzer, sample_images):
         mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
 
-        count, returned_path = orchestrator.analyze_images(sample_images)
+        count, returned_path, skipped = orchestrator.analyze_images(sample_images)
 
         assert count == 2
         assert returned_path is None
+        assert skipped == []
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +290,7 @@ class TestAnalysisOrchestratorCSV:
     def test_csv_not_written_when_filepath_is_none(self, orchestrator, mock_analyzer, sample_images, tmp_path):
         mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
 
-        _count, filepath = orchestrator.analyze_images(sample_images)
+        _count, filepath, _skipped = orchestrator.analyze_images(sample_images)
 
         assert filepath is None
 
@@ -335,7 +337,7 @@ class TestAnalysisOrchestratorOpenShift:
         ]
         mock_analyzer.analyze_image.return_value = _make_java_result("quay.io/my-org/my-image:latest")
 
-        count, _ = orchestrator.analyze_images(images)
+        count, _, _skipped = orchestrator.analyze_images(images)
 
         assert count == 1
         assert images[0]["java_binary"] == "/usr/bin/java"

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -404,7 +404,7 @@ class TestRegistryModePullSecret:
         mock_rootfs.return_value.create_rootfs_directory.return_value = (True, "OK")
 
         mock_orch = MagicMock()
-        mock_orch.analyze_images.return_value = (2, "/tmp/out/test.csv")
+        mock_orch.analyze_images.return_value = (2, "/tmp/out/test.csv", [])
 
         mock_gen_auth = MagicMock(return_value="/tmp/generated-auth.json")
 
@@ -573,7 +573,7 @@ class TestRegistryModeWithAnalysis:
         mock_rootfs.return_value.create_rootfs_directory.return_value = (True, "OK")
 
         mock_orch = MagicMock()
-        mock_orch.analyze_images.return_value = (1, "/tmp/out/test.csv")
+        mock_orch.analyze_images.return_value = (1, "/tmp/out/test.csv", [])
 
         with (
             patch("sys.argv", [*_REGISTRY_BASE_ARGS, "--analyze", "--rootfs-path", "/tmp/rootfs"]),
@@ -771,7 +771,7 @@ class TestOpenShiftModeNotBroken:
         mock_rootfs.return_value.create_rootfs_directory.return_value = (True, "OK")
 
         mock_orch = MagicMock()
-        mock_orch.analyze_images.return_value = (2, "/tmp/out/analyzed.csv")
+        mock_orch.analyze_images.return_value = (2, "/tmp/out/analyzed.csv", [])
 
         return args, mock_client, mock_collector, mock_rootfs, mock_orch
 

--- a/tests/test_image_timeout.py
+++ b/tests/test_image_timeout.py
@@ -1,0 +1,367 @@
+"""Tests for --image-timeout feature (issue #42)."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.analysis_orchestrator import AnalysisOrchestrator, _ImageTimeout
+from src.image_analyzer import ImageAnalysisResult
+
+# ---------------------------------------------------------------------------
+# Load the main script as a module (it has no .py extension)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "image-cgroupsv2-inspector"
+
+
+def _load_main_module():
+    loader = importlib.machinery.SourceFileLoader("main_script", str(_SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader("main_script", loader, origin=str(_SCRIPT_PATH))
+    module = importlib.util.module_from_spec(spec)
+    module.__file__ = str(_SCRIPT_PATH)
+    spec.loader.exec_module(module)
+    return module
+
+
+main_script = _load_main_module()
+parse_arguments = main_script.parse_arguments
+main = main_script.main
+
+_REGISTRY_BASE_ARGS = [
+    "image-cgroupsv2-inspector",
+    "--registry-url",
+    "https://quay.example.com",
+    "--registry-token",
+    "tok123",
+    "--registry-org",
+    "myorg",
+]
+
+
+def _sample_images(n=3):
+    return [
+        {
+            "source": "registry",
+            "container_name": "",
+            "namespace": "",
+            "object_type": "",
+            "object_name": "",
+            "registry_org": "myorg",
+            "registry_repo": f"repo{i}",
+            "image_name": f"quay.example.com/myorg/repo{i}:latest",
+            "image_id": "",
+        }
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestImageTimeoutArgParsing:
+    """Test --image-timeout argument parsing."""
+
+    def test_default_timeout_is_600(self):
+        with patch("sys.argv", _REGISTRY_BASE_ARGS):
+            args = parse_arguments()
+        assert args.image_timeout == 600
+
+    def test_custom_timeout_parsed(self):
+        with patch("sys.argv", [*_REGISTRY_BASE_ARGS, "--image-timeout", "30"]):
+            args = parse_arguments()
+        assert args.image_timeout == 30
+
+    def test_zero_timeout_parsed(self):
+        with patch("sys.argv", [*_REGISTRY_BASE_ARGS, "--image-timeout", "0"]):
+            args = parse_arguments()
+        assert args.image_timeout == 0
+
+    def test_timeout_works_with_openshift_args(self):
+        with patch(
+            "sys.argv",
+            [
+                "image-cgroupsv2-inspector",
+                "--api-url",
+                "https://api.cluster.example.com:6443",
+                "--token",
+                "tok",
+                "--image-timeout",
+                "120",
+            ],
+        ):
+            args = parse_arguments()
+        assert args.image_timeout == 120
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator timeout behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorTimeout:
+    """Test AnalysisOrchestrator timeout mechanism."""
+
+    @pytest.fixture
+    def mock_analyzer(self):
+        with patch("src.analysis_orchestrator.ImageAnalyzer") as mock_cls:
+            instance = MagicMock()
+            mock_cls.return_value = instance
+            yield instance
+
+    def test_timeout_skips_image_and_continues(self, mock_analyzer):
+        """A simulated timeout correctly skips the image and continues."""
+        good_result = ImageAnalysisResult(image_name="good", image_id="")
+
+        call_count = 0
+
+        def side_effect(image_name, debug=False):
+            nonlocal call_count
+            call_count += 1
+            if "repo0" in image_name:
+                raise _ImageTimeout()
+            return good_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=5,
+        )
+        # Bypass the real SIGALRM wrapper so we can trigger the exception directly
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
+            mock_analyzer.analyze_image(name, debug=debug)
+        )
+
+        images = _sample_images(3)
+        count, _, skipped = orchestrator.analyze_images(images)
+
+        assert "quay.example.com/myorg/repo0:latest" in skipped
+        assert len(skipped) == 1
+        assert count == 2
+
+    def test_skipped_image_gets_error_in_record(self, mock_analyzer):
+        """Timed-out images have an error message in their records."""
+        good_result = ImageAnalysisResult(image_name="good", image_id="")
+
+        def side_effect(image_name, debug=False):
+            if "repo0" in image_name:
+                raise _ImageTimeout()
+            return good_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=10,
+        )
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
+            mock_analyzer.analyze_image(name, debug=debug)
+        )
+
+        images = _sample_images(2)
+        orchestrator.analyze_images(images)
+
+        repo0_records = [r for r in images if "repo0" in r["image_name"]]
+        for rec in repo0_records:
+            assert "timed out" in rec.get("analysis_error", "")
+
+    def test_no_timeout_when_disabled(self, mock_analyzer):
+        """image_timeout=0 disables the timeout (no SIGALRM)."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=0,
+        )
+
+        images = _sample_images(1)
+        count, _, skipped = orchestrator.analyze_images(images)
+
+        assert count == 1
+        assert skipped == []
+
+    def test_skipped_summary_printed(self, mock_analyzer, capsys):
+        """Summary section is printed when images are skipped."""
+        good_result = ImageAnalysisResult(image_name="good", image_id="")
+
+        def side_effect(image_name, debug=False):
+            if "repo0" in image_name:
+                raise _ImageTimeout()
+            return good_result
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=30,
+        )
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
+            mock_analyzer.analyze_image(name, debug=debug)
+        )
+
+        images = _sample_images(2)
+        orchestrator.analyze_images(images)
+
+        out = capsys.readouterr().out
+        assert "=== Skipped images (timeout) ===" in out
+        assert "repo0" in out
+        assert "Total skipped: 1" in out
+
+    def test_warning_message_printed(self, mock_analyzer, capsys):
+        """WARNING line is printed for each timed-out image."""
+        def side_effect(image_name, debug=False):
+            raise _ImageTimeout()
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=42,
+        )
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
+            mock_analyzer.analyze_image(name, debug=debug)
+        )
+
+        images = _sample_images(1)
+        orchestrator.analyze_images(images)
+
+        out = capsys.readouterr().out
+        assert "WARNING: Skipping image" in out
+        assert "timed out after 42 seconds" in out
+
+    def test_no_summary_when_no_skips(self, mock_analyzer, capsys):
+        """No summary printed when all images succeed."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=600,
+        )
+
+        images = _sample_images(2)
+        _, _, skipped = orchestrator.analyze_images(images)
+
+        out = capsys.readouterr().out
+        assert "Skipped images" not in out
+        assert skipped == []
+
+    def test_cleanup_called_on_timeout(self, mock_analyzer):
+        """Cleanup is called for the timed-out image."""
+        def side_effect(image_name, debug=False):
+            raise _ImageTimeout()
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            image_timeout=10,
+        )
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
+            mock_analyzer.analyze_image(name, debug=debug)
+        )
+
+        images = _sample_images(1)
+        orchestrator.analyze_images(images)
+
+        mock_analyzer._cleanup.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Exit code in main()
+# ---------------------------------------------------------------------------
+
+
+class TestImageTimeoutExitCode:
+    """Test exit code 2 when images are skipped."""
+
+    def test_exit_code_2_on_skipped_images(self, capsys):
+        mock_quay = MagicMock()
+        mock_collector = MagicMock()
+        mock_collector.collect_images.return_value = _sample_images(1)
+
+        mock_rootfs = MagicMock()
+        mock_rootfs.return_value.get_rootfs_path.return_value = Path("/tmp/rootfs/rootfs")
+
+        mock_orch = MagicMock()
+        mock_orch.analyze_images.return_value = (0, "/tmp/out/test.csv", ["quay.example.com/myorg/repo0:latest"])
+
+        with (
+            patch("sys.argv", [*_REGISTRY_BASE_ARGS, "--analyze", "--rootfs-path", "/tmp/rootfs"]),
+            patch.object(main_script, "run_system_checks", return_value=True),
+            patch.object(main_script, "print_banner"),
+            patch("dotenv.load_dotenv"),
+            patch.object(main_script, "QuayClient", return_value=mock_quay),
+            patch.object(main_script, "RegistryCollector", return_value=mock_collector),
+            patch.object(main_script, "RootFSManager", mock_rootfs),
+            patch.object(main_script, "AnalysisOrchestrator", return_value=mock_orch),
+            patch.object(main_script, "generate_registry_auth_json", return_value="/tmp/auth.json"),
+            patch.object(main_script, "setup_rootfs", return_value=True),
+            patch.object(Path, "mkdir"),
+        ):
+            result = main()
+
+        assert result == 2
+
+    def test_exit_code_0_when_no_skips(self, capsys):
+        mock_quay = MagicMock()
+        mock_collector = MagicMock()
+        mock_collector.collect_images.return_value = _sample_images(1)
+
+        mock_rootfs = MagicMock()
+        mock_rootfs.return_value.get_rootfs_path.return_value = Path("/tmp/rootfs/rootfs")
+
+        mock_orch = MagicMock()
+        mock_orch.analyze_images.return_value = (1, "/tmp/out/test.csv", [])
+
+        with (
+            patch("sys.argv", [*_REGISTRY_BASE_ARGS, "--analyze", "--rootfs-path", "/tmp/rootfs"]),
+            patch.object(main_script, "run_system_checks", return_value=True),
+            patch.object(main_script, "print_banner"),
+            patch("dotenv.load_dotenv"),
+            patch.object(main_script, "QuayClient", return_value=mock_quay),
+            patch.object(main_script, "RegistryCollector", return_value=mock_collector),
+            patch.object(main_script, "RootFSManager", mock_rootfs),
+            patch.object(main_script, "AnalysisOrchestrator", return_value=mock_orch),
+            patch.object(main_script, "generate_registry_auth_json", return_value="/tmp/auth.json"),
+            patch.object(main_script, "setup_rootfs", return_value=True),
+            patch.object(Path, "mkdir"),
+        ):
+            result = main()
+
+        assert result == 0
+
+    def test_image_timeout_passed_to_orchestrator(self, capsys):
+        mock_quay = MagicMock()
+        mock_collector = MagicMock()
+        mock_collector.collect_images.return_value = _sample_images(1)
+
+        mock_rootfs = MagicMock()
+        mock_rootfs.return_value.get_rootfs_path.return_value = Path("/tmp/rootfs/rootfs")
+
+        mock_orch = MagicMock()
+        mock_orch.analyze_images.return_value = (1, "/tmp/out/test.csv", [])
+
+        with (
+            patch(
+                "sys.argv",
+                [*_REGISTRY_BASE_ARGS, "--analyze", "--rootfs-path", "/tmp/rootfs", "--image-timeout", "45"],
+            ),
+            patch.object(main_script, "run_system_checks", return_value=True),
+            patch.object(main_script, "print_banner"),
+            patch("dotenv.load_dotenv"),
+            patch.object(main_script, "QuayClient", return_value=mock_quay),
+            patch.object(main_script, "RegistryCollector", return_value=mock_collector),
+            patch.object(main_script, "RootFSManager", mock_rootfs),
+            patch.object(main_script, "AnalysisOrchestrator", return_value=mock_orch) as mock_orch_cls,
+            patch.object(main_script, "generate_registry_auth_json", return_value="/tmp/auth.json"),
+            patch.object(main_script, "setup_rootfs", return_value=True),
+            patch.object(Path, "mkdir"),
+        ):
+            main()
+
+        orch_kwargs = mock_orch_cls.call_args[1]
+        assert orch_kwargs["image_timeout"] == 45

--- a/tests/test_image_timeout.py
+++ b/tests/test_image_timeout.py
@@ -132,8 +132,8 @@ class TestOrchestratorTimeout:
             image_timeout=5,
         )
         # Bypass the real SIGALRM wrapper so we can trigger the exception directly
-        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
-            mock_analyzer.analyze_image(name, debug=debug)
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: mock_analyzer.analyze_image(
+            name, debug=debug
         )
 
         images = _sample_images(3)
@@ -158,8 +158,8 @@ class TestOrchestratorTimeout:
             rootfs_path="/tmp/rootfs",
             image_timeout=10,
         )
-        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
-            mock_analyzer.analyze_image(name, debug=debug)
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: mock_analyzer.analyze_image(
+            name, debug=debug
         )
 
         images = _sample_images(2)
@@ -199,8 +199,8 @@ class TestOrchestratorTimeout:
             rootfs_path="/tmp/rootfs",
             image_timeout=30,
         )
-        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
-            mock_analyzer.analyze_image(name, debug=debug)
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: mock_analyzer.analyze_image(
+            name, debug=debug
         )
 
         images = _sample_images(2)
@@ -213,6 +213,7 @@ class TestOrchestratorTimeout:
 
     def test_warning_message_printed(self, mock_analyzer, capsys):
         """WARNING line is printed for each timed-out image."""
+
         def side_effect(image_name, debug=False):
             raise _ImageTimeout()
 
@@ -222,8 +223,8 @@ class TestOrchestratorTimeout:
             rootfs_path="/tmp/rootfs",
             image_timeout=42,
         )
-        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
-            mock_analyzer.analyze_image(name, debug=debug)
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: mock_analyzer.analyze_image(
+            name, debug=debug
         )
 
         images = _sample_images(1)
@@ -251,6 +252,7 @@ class TestOrchestratorTimeout:
 
     def test_cleanup_called_on_timeout(self, mock_analyzer):
         """Cleanup is called for the timed-out image."""
+
         def side_effect(image_name, debug=False):
             raise _ImageTimeout()
 
@@ -260,8 +262,8 @@ class TestOrchestratorTimeout:
             rootfs_path="/tmp/rootfs",
             image_timeout=10,
         )
-        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: (
-            mock_analyzer.analyze_image(name, debug=debug)
+        orchestrator._analyze_with_timeout = lambda analyzer, name, debug=False: mock_analyzer.analyze_image(
+            name, debug=debug
         )
 
         images = _sample_images(1)

--- a/tests/test_image_timeout.py
+++ b/tests/test_image_timeout.py
@@ -251,7 +251,7 @@ class TestOrchestratorTimeout:
         assert skipped == []
 
     def test_cleanup_called_on_timeout(self, mock_analyzer):
-        """Cleanup is called for the timed-out image."""
+        """cleanup_image is called for the timed-out image."""
 
         def side_effect(image_name, debug=False):
             raise _ImageTimeout()
@@ -269,7 +269,7 @@ class TestOrchestratorTimeout:
         images = _sample_images(1)
         orchestrator.analyze_images(images)
 
-        mock_analyzer._cleanup.assert_called_once()
+        mock_analyzer.cleanup_image.assert_called_once_with("quay.example.com/myorg/repo0:latest", debug=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Wrap each image analysis in a SIGALRM-based timeout (default 600s). Timed-out images are skipped with a warning, cleaned up, and collected in a summary section. Exit code 2 distinguishes partial success from full success (0) and errors (1).