### PR TITLE
Add --resume flag to allow restarting interrupted scans (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ coverage.xml
 .DS_Store
 Thumbs.db
 
+# Scan state files (created by --resume)
+.state_*.json
+
 # rootfs directories (created by the tool)
 rootfs/

--- a/README.md
+++ b/README.md
@@ -393,6 +393,43 @@ QUAY_REGISTRY_ORG=myorg
 
 These can also be set in the `.env` file. CLI arguments override environment variables.
 
+### Resuming Interrupted Scans
+
+On large clusters or registries with thousands of images, scans can take hours. If a scan is interrupted (e.g., network failure, killed process), the `--resume` flag lets you restart where you left off instead of re-scanning all images from the beginning.
+
+A JSON state file is written automatically during every `--analyze` run, tracking which images have been processed. The state file is stored in the output directory (or the directory specified by `--state-dir`).
+
+```bash
+# First run — interrupted after scanning 2000 of 4900 images
+./image-cgroupsv2-inspector --rootfs-path /tmp/images --analyze
+
+# Resume — skips the 2000 already-scanned images, scans remaining 2900
+./image-cgroupsv2-inspector --rootfs-path /tmp/images --analyze --resume
+
+# Store state files in a custom directory
+./image-cgroupsv2-inspector --rootfs-path /tmp/images --analyze --resume --state-dir /var/tmp/scan-state
+
+# Clean up the state file when done (or to force a fresh scan)
+./image-cgroupsv2-inspector --clean-state
+
+# Registry mode works the same way
+./image-cgroupsv2-inspector \
+  --registry-url https://quay.example.com \
+  --registry-token <token> \
+  --registry-org myorg \
+  --rootfs-path /tmp/images \
+  --analyze --resume
+```
+
+**State file details:**
+
+- Named `.state_<target>.json` (e.g., `.state_ocp-prod.json` or `.state_quay.example.com.json`)
+- Written after each image is processed, using atomic writes to prevent corruption
+- Contains a list of completed image names and timestamps
+- If `--resume` is used without a prior state file, a warning is printed and a full scan starts
+- Images that time out or fail are also marked as completed to avoid retrying them indefinitely
+- `--clean-state` deletes the state file and exits immediately (code `0`)
+
 ### Command Line Options
 
 **OpenShift mode options:**
@@ -430,6 +467,9 @@ These can also be set in the `.env` file. CLI arguments override environment var
 | `--skip-collection` | Skip image collection (useful for testing rootfs setup) |
 | `--skip-disk-check` | Skip the 20GB minimum free disk space check. A warning will be logged instead of stopping execution |
 | `--image-timeout` | Maximum seconds for pulling and scanning each individual image (default: `600`). If an image exceeds this limit it is skipped with a warning and the tool exits with code `2` |
+| `--resume` | Resume an interrupted scan by skipping images that were already scanned in a previous run. Reads progress from a JSON state file |
+| `--clean-state` | Delete the state file for the current target (cluster or registry) and exit immediately with code `0` |
+| `--state-dir` | Directory where state files are stored (default: same as `--output-dir`) |
 | `--log-to-file` | Enable logging to file |
 | `--log-file` | Path to log file (default: `image-cgroupsv2-inspector.log`). Implies `--log-to-file` |
 | `-v, --verbose` | Enable verbose output |

--- a/README.md
+++ b/README.md
@@ -428,10 +428,12 @@ A JSON state file is written automatically during every `--analyze` run, trackin
 
 - Named `.state_<target>.json` (e.g., `.state_ocp-prod.json` or `.state_quay.example.com.json`)
 - Written after each image is processed, using atomic writes to prevent corruption
-- Contains a list of completed image names, timestamps, and the CSV output path
-- On resume, the same CSV file from the first run is reused so all results end up in a single file
+- Contains completed image names with their analysis results, timestamps, and the CSV output path
+- On resume, the same CSV file from the first run is reused so all results accumulate in a single file
+- Analysis results from previous runs are restored into the CSV, so no data is lost across interruptions
 - If `--resume` is used without a prior state file, a warning is printed and a full scan starts
-- Images that time out or fail are also marked as completed to avoid retrying them indefinitely
+- Successfully scanned images are skipped on resume; images that failed or timed out are **retried** automatically
+- The state file tracks three categories: `completed_images`, `error_images`, and `timeout_images`
 - `--clean-state` deletes the state file and exits immediately (code `0`). Pass a target name (e.g. `--clean-state ocp-prod`) to skip the cluster/registry connection
 
 ### Command Line Options

--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ A JSON state file is written automatically during every `--analyze` run, trackin
 # Clean up the state file when done (or to force a fresh scan)
 ./image-cgroupsv2-inspector --clean-state
 
+# Clean up by target name (no cluster/registry connection needed)
+./image-cgroupsv2-inspector --clean-state ocp-prod
+
 # Registry mode works the same way
 ./image-cgroupsv2-inspector \
   --registry-url https://quay.example.com \
@@ -428,7 +431,7 @@ A JSON state file is written automatically during every `--analyze` run, trackin
 - Contains a list of completed image names and timestamps
 - If `--resume` is used without a prior state file, a warning is printed and a full scan starts
 - Images that time out or fail are also marked as completed to avoid retrying them indefinitely
-- `--clean-state` deletes the state file and exits immediately (code `0`)
+- `--clean-state` deletes the state file and exits immediately (code `0`). Pass a target name (e.g. `--clean-state ocp-prod`) to skip the cluster/registry connection
 
 ### Command Line Options
 
@@ -468,7 +471,7 @@ A JSON state file is written automatically during every `--analyze` run, trackin
 | `--skip-disk-check` | Skip the 20GB minimum free disk space check. A warning will be logged instead of stopping execution |
 | `--image-timeout` | Maximum seconds for pulling and scanning each individual image (default: `600`). If an image exceeds this limit it is skipped with a warning and the tool exits with code `2` |
 | `--resume` | Resume an interrupted scan by skipping images that were already scanned in a previous run. Reads progress from a JSON state file |
-| `--clean-state` | Delete the state file for the current target (cluster or registry) and exit immediately with code `0` |
+| `--clean-state [TARGET]` | Delete the state file and exit with code `0`. When a target name is given (e.g. `--clean-state ocp-prod`), no cluster/registry connection is needed |
 | `--state-dir` | Directory where state files are stored (default: same as `--output-dir`) |
 | `--log-to-file` | Enable logging to file |
 | `--log-file` | Path to log file (default: `image-cgroupsv2-inspector.log`). Implies `--log-to-file` |

--- a/README.md
+++ b/README.md
@@ -428,7 +428,8 @@ A JSON state file is written automatically during every `--analyze` run, trackin
 
 - Named `.state_<target>.json` (e.g., `.state_ocp-prod.json` or `.state_quay.example.com.json`)
 - Written after each image is processed, using atomic writes to prevent corruption
-- Contains a list of completed image names and timestamps
+- Contains a list of completed image names, timestamps, and the CSV output path
+- On resume, the same CSV file from the first run is reused so all results end up in a single file
 - If `--resume` is used without a prior state file, a warning is printed and a full scan starts
 - Images that time out or fail are also marked as completed to avoid retrying them indefinitely
 - `--clean-state` deletes the state file and exits immediately (code `0`). Pass a target name (e.g. `--clean-state ocp-prod`) to skip the cluster/registry connection

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -259,9 +259,11 @@ The tool will save credentials to .env file after successful connection.
     parser.add_argument(
         "--clean-state",
         dest="clean_state",
-        action="store_true",
-        default=False,
-        help="Delete the state file for the current target and exit",
+        nargs="?",
+        const=True,
+        default=None,
+        help="Delete the state file and exit. Optionally pass a target name to skip cluster/registry "
+        "connection (e.g. --clean-state ocp-prod)",
     )
 
     parser.add_argument(
@@ -493,6 +495,10 @@ def main() -> int:
     if not args.registry_org:
         args.registry_org = os.environ.get("QUAY_REGISTRY_ORG", "")
 
+    # Handle --clean-state with explicit target (no connection needed)
+    if isinstance(args.clean_state, str):
+        return _handle_clean_state(args.clean_state, state_dir)
+
     is_registry_mode = bool(args.registry_url)
 
     # Mutual exclusion check
@@ -518,7 +524,7 @@ def main() -> int:
         if parsed.port:
             registry_host = f"{parsed.hostname}:{parsed.port}"
 
-        if args.clean_state:
+        if args.clean_state is True:
             return _handle_clean_state(registry_host, state_dir)
 
         state_file_path = _build_state_file_path(registry_host, state_dir)
@@ -610,6 +616,7 @@ def main() -> int:
                     image_timeout=args.image_timeout,
                     state_file_path=state_file_path,
                     resume=args.resume,
+                    target=registry_host,
                 )
                 _, csv_path, skipped = orchestrator.analyze_images(
                     images=images,
@@ -686,7 +693,7 @@ def main() -> int:
         if log_to_file:
             logger.info(f"Connected successfully to cluster: {client.cluster_name}")
 
-        if args.clean_state:
+        if args.clean_state is True:
             client.disconnect()
             return _handle_clean_state(client.cluster_name, state_dir)
 
@@ -783,6 +790,7 @@ def main() -> int:
                 image_timeout=args.image_timeout,
                 state_file_path=state_file_path,
                 resume=args.resume,
+                target=client.cluster_name,
             )
             _, csv_path, skipped = orchestrator.analyze_images(
                 images=image_dicts,

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -35,6 +35,7 @@ from src.openshift_client import OpenShiftClient
 from src.quay_client import QuayClient, QuayClientError
 from src.registry_collector import RegistryCollector
 from src.rootfs_manager import RootFSManager
+from src.scan_state import ScanState
 from src.system_checks import run_system_checks
 
 
@@ -245,6 +246,32 @@ The tool will save credentials to .env file after successful connection.
         help="Only scan the N most recent tags per repository",
     )
 
+    # --- Resume / state ---
+
+    parser.add_argument(
+        "--resume",
+        dest="resume",
+        action="store_true",
+        default=False,
+        help="Resume an interrupted scan by skipping already-scanned images (reads from state file)",
+    )
+
+    parser.add_argument(
+        "--clean-state",
+        dest="clean_state",
+        action="store_true",
+        default=False,
+        help="Delete the state file for the current target and exit",
+    )
+
+    parser.add_argument(
+        "--state-dir",
+        dest="state_dir",
+        type=str,
+        default=None,
+        help="Directory where state files are stored (default: same as --output-dir)",
+    )
+
     # --- Timeout ---
 
     parser.add_argument(
@@ -390,6 +417,22 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
     print(f"      Images skipped (timeout): {skipped_count}")
 
 
+def _build_state_file_path(target: str, state_dir: str) -> str:
+    """Return the full path to the state file for *target*."""
+    return str(Path(state_dir) / ScanState.build_state_filename(target))
+
+
+def _handle_clean_state(target: str, state_dir: str) -> int:
+    """Delete the state file for *target* and return exit code 0."""
+    path = _build_state_file_path(target, state_dir)
+    if Path(path).exists():
+        os.remove(path)
+        print(f"State file removed: {path}")
+    else:
+        print("No state file found")
+    return 0
+
+
 def main() -> int:
     """Main entry point."""
     print_banner()
@@ -399,6 +442,9 @@ def main() -> int:
 
     # Change to script directory for relative paths
     os.chdir(script_dir)
+
+    # Resolve state directory early (default = output dir)
+    state_dir = args.state_dir if args.state_dir else args.output_dir
 
     # Set up logging
     # If --log-file is specified with a non-default value, imply --log-to-file
@@ -471,6 +517,11 @@ def main() -> int:
         registry_host = parsed.hostname
         if parsed.port:
             registry_host = f"{parsed.hostname}:{parsed.port}"
+
+        if args.clean_state:
+            return _handle_clean_state(registry_host, state_dir)
+
+        state_file_path = _build_state_file_path(registry_host, state_dir)
 
         print(f"\n🔌 Connecting to Quay registry: {args.registry_url}")
         if log_to_file:
@@ -557,6 +608,8 @@ def main() -> int:
                     rootfs_path=rootfs_path,
                     pull_secret_path=pull_secret_path,
                     image_timeout=args.image_timeout,
+                    state_file_path=state_file_path,
+                    resume=args.resume,
                 )
                 _, csv_path, skipped = orchestrator.analyze_images(
                     images=images,
@@ -632,6 +685,12 @@ def main() -> int:
         client.connect()
         if log_to_file:
             logger.info(f"Connected successfully to cluster: {client.cluster_name}")
+
+        if args.clean_state:
+            client.disconnect()
+            return _handle_clean_state(client.cluster_name, state_dir)
+
+        state_file_path = _build_state_file_path(client.cluster_name, state_dir)
 
     except ValueError as e:
         print(f"\n✗ Configuration error: {e}")
@@ -722,6 +781,8 @@ def main() -> int:
                 internal_registry_route=internal_registry_route,
                 openshift_token=client.token,
                 image_timeout=args.image_timeout,
+                state_file_path=state_file_path,
+                resume=args.resume,
             )
             _, csv_path, skipped = orchestrator.analyze_images(
                 images=image_dicts,

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -12,6 +12,7 @@ import traceback
 
 from .image_analyzer import ImageAnalysisResult, ImageAnalyzer
 from .registry_collector import CSV_COLUMNS
+from .scan_state import STATE_VERSION, ScanState
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,9 @@ class AnalysisOrchestrator:
             (only for OpenShift mode, None for registry mode).
         image_timeout: Maximum seconds for pulling and scanning each
             individual image.  0 disables the timeout.
+        state_file_path: Path to the JSON state file for resume support.
+            When set, scan progress is saved after each image.
+        resume: If True, load the state file and skip already-scanned images.
     """
 
     def __init__(
@@ -49,12 +53,16 @@ class AnalysisOrchestrator:
         internal_registry_route: str | None = None,
         openshift_token: str | None = None,
         image_timeout: int = 600,
+        state_file_path: str | None = None,
+        resume: bool = False,
     ) -> None:
         self.rootfs_path = rootfs_path
         self.pull_secret_path = pull_secret_path
         self.internal_registry_route = internal_registry_route
         self.openshift_token = openshift_token
         self.image_timeout = image_timeout
+        self.state_file_path = state_file_path
+        self.resume = resume
 
     def _save_csv(self, images: list[dict], filepath: str) -> None:
         """Write image records to CSV using the unified schema."""
@@ -110,6 +118,41 @@ class AnalysisOrchestrator:
                 seen.add(name)
                 unique_image_names.append(name)
 
+        # --- resume / state setup ---
+        scan_state: ScanState | None = None
+        if self.state_file_path:
+            if self.resume:
+                scan_state = ScanState.load(self.state_file_path)
+                if scan_state.completed_count == 0 and scan_state.target == "":
+                    print("WARNING: --resume specified but no state file found; starting full scan")
+                    if logger:
+                        logger.warning("--resume specified but no state file found; starting full scan")
+                    scan_state = ScanState(target="resume")
+                else:
+                    if scan_state.version != STATE_VERSION:
+                        print(
+                            f"WARNING: state file version {scan_state.version} "
+                            f"differs from current version {STATE_VERSION}; proceeding anyway"
+                        )
+                        if logger:
+                            logger.warning(
+                                "State file version %d differs from current version %d",
+                                scan_state.version,
+                                STATE_VERSION,
+                            )
+                    already = [n for n in unique_image_names if scan_state.is_completed(n)]
+                    remaining = [n for n in unique_image_names if not scan_state.is_completed(n)]
+                    print(f"Resuming: skipping {len(already)} already-scanned images ({len(remaining)} remaining)")
+                    if logger:
+                        logger.info(
+                            "Resuming: skipping %d already-scanned images (%d remaining)",
+                            len(already),
+                            len(remaining),
+                        )
+                    unique_image_names = remaining
+            else:
+                scan_state = ScanState(target="scan")
+
         total = len(unique_image_names)
         analyzed_count = 0
         skipped_images: list[str] = []
@@ -146,6 +189,10 @@ class AnalysisOrchestrator:
                 if debug:
                     traceback.print_exc()
                 results_cache[image_name] = ImageAnalysisResult(image_name=image_name, image_id="", error=str(exc))
+
+            if scan_state is not None:
+                scan_state.mark_completed(image_name)
+                scan_state.save(self.state_file_path)
 
             self._apply_results(images, results_cache)
 

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -12,7 +12,7 @@ import traceback
 
 from .image_analyzer import ImageAnalysisResult, ImageAnalyzer
 from .registry_collector import CSV_COLUMNS
-from .scan_state import STATE_VERSION, ScanState
+from .scan_state import ANALYSIS_KEYS, STATE_VERSION, ScanState
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ class AnalysisOrchestrator:
         if self.state_file_path:
             if self.resume:
                 scan_state = ScanState.load(self.state_file_path)
-                if scan_state.completed_count == 0 and scan_state.target == "":
+                if scan_state.scanned_count == 0 and scan_state.target == "":
                     print("WARNING: --resume specified but no state file found; starting full scan")
                     if logger:
                         logger.warning("--resume specified but no state file found; starting full scan")
@@ -146,13 +146,25 @@ class AnalysisOrchestrator:
                             )
                     if scan_state.csv_filepath and csv_filepath:
                         csv_filepath = scan_state.csv_filepath
-                    already = [n for n in unique_image_names if scan_state.is_completed(n)]
+
+                    # Restore cached analysis results into image records
+                    for record in images:
+                        cached = scan_state.get_result(record.get("image_name", ""))
+                        if cached:
+                            for key in ANALYSIS_KEYS:
+                                record[key] = cached.get(key, "")
+
+                    skipped = [n for n in unique_image_names if scan_state.is_completed(n)]
                     remaining = [n for n in unique_image_names if not scan_state.is_completed(n)]
-                    print(f"Resuming: skipping {len(already)} already-scanned images ({len(remaining)} remaining)")
+                    print(f"Resuming: skipping {len(skipped)} already-scanned images ({len(remaining)} remaining)")
+                    if scan_state.error_count:
+                        print(f"  Retrying {scan_state.error_count} previously failed images")
+                    if scan_state.timeout_count:
+                        print(f"  Retrying {scan_state.timeout_count} previously timed-out images")
                     if logger:
                         logger.info(
                             "Resuming: skipping %d already-scanned images (%d remaining)",
-                            len(already),
+                            len(skipped),
                             len(remaining),
                         )
                     unique_image_names = remaining
@@ -196,11 +208,18 @@ class AnalysisOrchestrator:
                     traceback.print_exc()
                 results_cache[image_name] = ImageAnalysisResult(image_name=image_name, image_id="", error=str(exc))
 
-            if scan_state is not None and self.state_file_path:
-                scan_state.mark_completed(image_name)
-                scan_state.save(self.state_file_path)
-
             self._apply_results(images, results_cache)
+
+            if scan_state is not None and self.state_file_path:
+                result_dict = self._collect_result_dict(images, image_name)
+                cached_result = results_cache.get(image_name)
+                if image_name in skipped_images:
+                    scan_state.mark_timeout(image_name, result_dict)
+                elif cached_result and cached_result.error:
+                    scan_state.mark_error(image_name, result_dict)
+                else:
+                    scan_state.mark_completed(image_name, result_dict)
+                scan_state.save(self.state_file_path)
 
             if csv_filepath:
                 self._save_csv(images, csv_filepath)
@@ -246,6 +265,14 @@ class AnalysisOrchestrator:
             raise
         finally:
             signal.signal(signal.SIGALRM, old_handler)
+
+    @staticmethod
+    def _collect_result_dict(images: list[dict], image_name: str) -> dict[str, str]:
+        """Extract the analysis result fields for *image_name* from the image records."""
+        for record in images:
+            if record.get("image_name") == image_name:
+                return {k: record.get(k, "") for k in ANALYSIS_KEYS}
+        return {}
 
     @staticmethod
     def _apply_results(

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -131,7 +131,7 @@ class AnalysisOrchestrator:
                     print("WARNING: --resume specified but no state file found; starting full scan")
                     if logger:
                         logger.warning("--resume specified but no state file found; starting full scan")
-                    scan_state = ScanState(target=self.target)
+                    scan_state = ScanState(target=self.target, csv_filepath=csv_filepath)
                 else:
                     if scan_state.version != STATE_VERSION:
                         print(
@@ -144,6 +144,8 @@ class AnalysisOrchestrator:
                                 scan_state.version,
                                 STATE_VERSION,
                             )
+                    if scan_state.csv_filepath and csv_filepath:
+                        csv_filepath = scan_state.csv_filepath
                     already = [n for n in unique_image_names if scan_state.is_completed(n)]
                     remaining = [n for n in unique_image_names if not scan_state.is_completed(n)]
                     print(f"Resuming: skipping {len(already)} already-scanned images ({len(remaining)} remaining)")
@@ -155,7 +157,7 @@ class AnalysisOrchestrator:
                         )
                     unique_image_names = remaining
             else:
-                scan_state = ScanState(target=self.target)
+                scan_state = ScanState(target=self.target, csv_filepath=csv_filepath)
 
         total = len(unique_image_names)
         analyzed_count = 0

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -44,6 +44,8 @@ class AnalysisOrchestrator:
         state_file_path: Path to the JSON state file for resume support.
             When set, scan progress is saved after each image.
         resume: If True, load the state file and skip already-scanned images.
+        target: Identifier for the scan target (cluster name or registry host).
+            Written into the state file for debugging/traceability.
     """
 
     def __init__(
@@ -55,6 +57,7 @@ class AnalysisOrchestrator:
         image_timeout: int = 600,
         state_file_path: str | None = None,
         resume: bool = False,
+        target: str = "",
     ) -> None:
         self.rootfs_path = rootfs_path
         self.pull_secret_path = pull_secret_path
@@ -63,6 +66,7 @@ class AnalysisOrchestrator:
         self.image_timeout = image_timeout
         self.state_file_path = state_file_path
         self.resume = resume
+        self.target = target
 
     def _save_csv(self, images: list[dict], filepath: str) -> None:
         """Write image records to CSV using the unified schema."""
@@ -127,7 +131,7 @@ class AnalysisOrchestrator:
                     print("WARNING: --resume specified but no state file found; starting full scan")
                     if logger:
                         logger.warning("--resume specified but no state file found; starting full scan")
-                    scan_state = ScanState(target="resume")
+                    scan_state = ScanState(target=self.target)
                 else:
                     if scan_state.version != STATE_VERSION:
                         print(
@@ -151,7 +155,7 @@ class AnalysisOrchestrator:
                         )
                     unique_image_names = remaining
             else:
-                scan_state = ScanState(target="scan")
+                scan_state = ScanState(target=self.target)
 
         total = len(unique_image_names)
         analyzed_count = 0
@@ -190,7 +194,7 @@ class AnalysisOrchestrator:
                     traceback.print_exc()
                 results_cache[image_name] = ImageAnalysisResult(image_name=image_name, image_id="", error=str(exc))
 
-            if scan_state is not None:
+            if scan_state is not None and self.state_file_path:
                 scan_state.mark_completed(image_name)
                 scan_state.save(self.state_file_path)
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -1,0 +1,104 @@
+"""
+Scan State Module
+
+Manages persistent scan state for resume support.
+Tracks which images have already been scanned so that interrupted scans
+can be resumed without re-processing completed images.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+STATE_VERSION = 1
+
+
+class ScanState:
+    """Persistent scan state backed by a JSON file.
+
+    Args:
+        target: Identifier for the scan target (cluster name or registry host).
+        completed_images: Set of image names already processed.
+        started_at: ISO-8601 timestamp when the scan started.
+        updated_at: ISO-8601 timestamp of the last state update.
+        version: State file schema version.
+    """
+
+    def __init__(
+        self,
+        target: str,
+        completed_images: set[str] | None = None,
+        started_at: str | None = None,
+        updated_at: str | None = None,
+        version: int = STATE_VERSION,
+    ) -> None:
+        self.version = version
+        self.target = target
+        now = datetime.now(UTC).isoformat()
+        self.started_at = started_at or now
+        self.updated_at = updated_at or now
+        self._completed: set[str] = set(completed_images) if completed_images else set()
+
+    @property
+    def completed_count(self) -> int:
+        return len(self._completed)
+
+    def is_completed(self, image_name: str) -> bool:
+        return image_name in self._completed
+
+    def mark_completed(self, image_name: str) -> None:
+        """Add an image to the completed set and update the timestamp."""
+        self._completed.add(image_name)
+        self.updated_at = datetime.now(UTC).isoformat()
+
+    def save(self, path: str | Path) -> None:
+        """Atomically write the state to *path* (write tmp + os.replace)."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "version": self.version,
+            "target": self.target,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "completed_images": sorted(self._completed),
+        }
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+                f.write("\n")
+            os.replace(tmp, str(path))
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
+
+    @classmethod
+    def load(cls, path: str | Path) -> ScanState:
+        """Load state from *path*.  Returns an empty state if the file
+        does not exist or cannot be parsed."""
+        path = Path(path)
+        if not path.exists():
+            return cls(target="")
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return cls(target="")
+        return cls(
+            target=data.get("target", ""),
+            completed_images=set(data.get("completed_images", [])),
+            started_at=data.get("started_at"),
+            updated_at=data.get("updated_at"),
+            version=data.get("version", STATE_VERSION),
+        )
+
+    @staticmethod
+    def build_state_filename(target: str) -> str:
+        """Build the state file name for a given target (cluster or registry host)."""
+        safe = target.replace("/", "_").replace(":", "_")
+        return f".state_{safe}.json"

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -15,15 +15,41 @@ import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-STATE_VERSION = 1
+STATE_VERSION = 2
+
+ANALYSIS_KEYS = (
+    "java_binary",
+    "java_version",
+    "java_cgroup_v2_compatible",
+    "node_binary",
+    "node_version",
+    "node_cgroup_v2_compatible",
+    "dotnet_binary",
+    "dotnet_version",
+    "dotnet_cgroup_v2_compatible",
+    "analysis_error",
+)
 
 
 class ScanState:
     """Persistent scan state backed by a JSON file.
 
+    Images are tracked in three categories:
+
+    - **completed**: successfully analysed — skipped on resume.
+    - **error**: failed with an analysis error — retried on resume.
+    - **timeout**: exceeded the per-image timeout — retried on resume.
+
+    Analysis results for completed images are cached in ``image_results``
+    so they can be restored into the CSV on resume without re-scanning.
+
     Args:
         target: Identifier for the scan target (cluster name or registry host).
-        completed_images: Set of image names already processed.
+        completed_images: Set of successfully scanned image names.
+        error_images: Set of image names that failed with an error.
+        timeout_images: Set of image names that timed out.
+        image_results: Mapping of image name -> analysis result dict
+            (only for completed images).
         started_at: ISO-8601 timestamp when the scan started.
         updated_at: ISO-8601 timestamp of the last state update.
         version: State file schema version.
@@ -34,6 +60,9 @@ class ScanState:
         self,
         target: str,
         completed_images: set[str] | None = None,
+        error_images: set[str] | None = None,
+        timeout_images: set[str] | None = None,
+        image_results: dict[str, dict[str, str]] | None = None,
         started_at: str | None = None,
         updated_at: str | None = None,
         version: int = STATE_VERSION,
@@ -45,19 +74,71 @@ class ScanState:
         self.started_at = started_at or now
         self.updated_at = updated_at or now
         self._completed: set[str] = set(completed_images) if completed_images else set()
+        self._error: set[str] = set(error_images) if error_images else set()
+        self._timeout: set[str] = set(timeout_images) if timeout_images else set()
+        self._results: dict[str, dict[str, str]] = dict(image_results) if image_results else {}
         self.csv_filepath = csv_filepath
+
+    # -- counts / queries --
 
     @property
     def completed_count(self) -> int:
         return len(self._completed)
 
+    @property
+    def error_count(self) -> int:
+        return len(self._error)
+
+    @property
+    def timeout_count(self) -> int:
+        return len(self._timeout)
+
+    @property
+    def scanned_count(self) -> int:
+        """Total images processed (completed + error + timeout)."""
+        return len(self._completed) + len(self._error) + len(self._timeout)
+
     def is_completed(self, image_name: str) -> bool:
         return image_name in self._completed
 
-    def mark_completed(self, image_name: str) -> None:
-        """Add an image to the completed set and update the timestamp."""
+    def is_scanned(self, image_name: str) -> bool:
+        """True if the image was processed in any category."""
+        return image_name in self._completed or image_name in self._error or image_name in self._timeout
+
+    def get_result(self, image_name: str) -> dict[str, str] | None:
+        """Return the cached analysis result dict, or None."""
+        return self._results.get(image_name)
+
+    # -- mutations --
+
+    def mark_completed(self, image_name: str, result: dict[str, str] | None = None) -> None:
+        """Record a successfully scanned image with its analysis results."""
         self._completed.add(image_name)
+        self._error.discard(image_name)
+        self._timeout.discard(image_name)
+        if result is not None:
+            self._results[image_name] = {k: result.get(k, "") for k in ANALYSIS_KEYS}
         self.updated_at = datetime.now(UTC).isoformat()
+
+    def mark_error(self, image_name: str, result: dict[str, str] | None = None) -> None:
+        """Record an image that failed with an error."""
+        self._error.add(image_name)
+        self._completed.discard(image_name)
+        self._timeout.discard(image_name)
+        if result is not None:
+            self._results[image_name] = {k: result.get(k, "") for k in ANALYSIS_KEYS}
+        self.updated_at = datetime.now(UTC).isoformat()
+
+    def mark_timeout(self, image_name: str, result: dict[str, str] | None = None) -> None:
+        """Record an image that exceeded the timeout."""
+        self._timeout.add(image_name)
+        self._completed.discard(image_name)
+        self._error.discard(image_name)
+        if result is not None:
+            self._results[image_name] = {k: result.get(k, "") for k in ANALYSIS_KEYS}
+        self.updated_at = datetime.now(UTC).isoformat()
+
+    # -- persistence --
 
     def save(self, path: str | Path) -> None:
         """Atomically write the state to *path* (write tmp + os.replace)."""
@@ -70,6 +151,9 @@ class ScanState:
             "updated_at": self.updated_at,
             "csv_filepath": self.csv_filepath,
             "completed_images": sorted(self._completed),
+            "error_images": sorted(self._error),
+            "timeout_images": sorted(self._timeout),
+            "image_results": self._results,
         }
         fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
         try:
@@ -93,9 +177,16 @@ class ScanState:
             data = json.loads(path.read_text())
         except (json.JSONDecodeError, OSError):
             return cls(target="")
+
+        # v1 state files stored everything in completed_images (including
+        # errors/timeouts) and had no image_results.  Treat them as
+        # completed so existing state files still work on upgrade.
         return cls(
             target=data.get("target", ""),
             completed_images=set(data.get("completed_images", [])),
+            error_images=set(data.get("error_images", [])),
+            timeout_images=set(data.get("timeout_images", [])),
+            image_results=data.get("image_results", {}),
             started_at=data.get("started_at"),
             updated_at=data.get("updated_at"),
             version=data.get("version", STATE_VERSION),

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -27,6 +27,7 @@ class ScanState:
         started_at: ISO-8601 timestamp when the scan started.
         updated_at: ISO-8601 timestamp of the last state update.
         version: State file schema version.
+        csv_filepath: Path to the CSV output file used for this scan.
     """
 
     def __init__(
@@ -36,6 +37,7 @@ class ScanState:
         started_at: str | None = None,
         updated_at: str | None = None,
         version: int = STATE_VERSION,
+        csv_filepath: str | None = None,
     ) -> None:
         self.version = version
         self.target = target
@@ -43,6 +45,7 @@ class ScanState:
         self.started_at = started_at or now
         self.updated_at = updated_at or now
         self._completed: set[str] = set(completed_images) if completed_images else set()
+        self.csv_filepath = csv_filepath
 
     @property
     def completed_count(self) -> int:
@@ -65,6 +68,7 @@ class ScanState:
             "target": self.target,
             "started_at": self.started_at,
             "updated_at": self.updated_at,
+            "csv_filepath": self.csv_filepath,
             "completed_images": sorted(self._completed),
         }
         fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
@@ -95,6 +99,7 @@ class ScanState:
             started_at=data.get("started_at"),
             updated_at=data.get("updated_at"),
             version=data.get("version", STATE_VERSION),
+            csv_filepath=data.get("csv_filepath"),
         )
 
     @staticmethod

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -8,6 +8,7 @@ import pytest
 from src.analysis_orchestrator import AnalysisOrchestrator
 from src.image_analyzer import BinaryInfo, ImageAnalysisResult
 from src.registry_collector import CSV_COLUMNS
+from src.scan_state import ScanState
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -377,3 +378,119 @@ class TestAnalysisOrchestratorOpenShift:
 
             args = mock_cls.call_args[0]
             assert args[3] == "sha256~mytoken"
+
+
+# ---------------------------------------------------------------------------
+# TestAnalysisOrchestratorResume
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisOrchestratorResume:
+    """Test resume / state-file integration."""
+
+    def test_resume_skips_completed_images(self, mock_analyzer, sample_images, tmp_path):
+        """With resume=True and a pre-populated state, already-scanned images are skipped."""
+        state_path = str(tmp_path / ".state_test.json")
+        pre_state = ScanState(target="test")
+        pre_state.mark_completed("quay.example.com/testorg/java-app:17")
+        pre_state.save(state_path)
+
+        mock_analyzer.analyze_image.return_value = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=True,
+        )
+        count, _, _skipped = orchestrator.analyze_images(sample_images)
+
+        assert count == 1
+        assert mock_analyzer.analyze_image.call_count == 1
+        mock_analyzer.analyze_image.assert_called_once_with("quay.example.com/testorg/node-app:20", debug=False)
+
+    def test_state_file_written_without_resume(self, mock_analyzer, sample_images, tmp_path):
+        """Without --resume, the state file is still written progressively."""
+        state_path = str(tmp_path / ".state_test.json")
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=False,
+        )
+        orchestrator.analyze_images(sample_images)
+
+        assert (tmp_path / ".state_test.json").exists()
+        loaded = ScanState.load(state_path)
+        assert loaded.completed_count == 2
+
+    def test_state_file_not_written_when_path_is_none(self, mock_analyzer, sample_images, tmp_path):
+        """When state_file_path is None, no state file should be created."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=None,
+            resume=False,
+        )
+        orchestrator.analyze_images(sample_images)
+
+        assert len(list(tmp_path.glob("*.json"))) == 0
+
+    def test_resume_with_missing_state_file(self, mock_analyzer, sample_images, tmp_path):
+        """--resume with no prior state file: warn and do full scan."""
+        state_path = str(tmp_path / ".state_missing.json")
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=True,
+        )
+        count, _, _skipped = orchestrator.analyze_images(sample_images)
+
+        assert count == 2
+        assert mock_analyzer.analyze_image.call_count == 2
+
+    def test_timed_out_image_marked_completed(self, mock_analyzer, sample_images, tmp_path):
+        """Timed-out images should be marked as completed in the state file."""
+        state_path = str(tmp_path / ".state_test.json")
+
+        def side_effect(image_name, debug=False):
+            if "java-app" in image_name:
+                raise RuntimeError("pull failed")
+            return _make_node_result(image_name)
+
+        mock_analyzer.analyze_image.side_effect = side_effect
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=False,
+        )
+        orchestrator.analyze_images(sample_images)
+
+        loaded = ScanState.load(state_path)
+        assert loaded.is_completed("quay.example.com/testorg/java-app:17")
+        assert loaded.is_completed("quay.example.com/testorg/node-app:20")
+
+    def test_clean_state_deletes_file(self, tmp_path):
+        """Simulate --clean-state: the state file is removed."""
+        state_path = tmp_path / ".state_test.json"
+        ScanState(target="t").save(state_path)
+        assert state_path.exists()
+
+        import os
+
+        os.remove(str(state_path))
+        assert not state_path.exists()
+
+    def test_clean_state_no_file(self, tmp_path):
+        """--clean-state with no existing file: no error."""
+        state_path = tmp_path / ".state_missing.json"
+        assert not state_path.exists()

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -515,6 +515,47 @@ class TestAnalysisOrchestratorResume:
 
         assert count == 2
 
+    def test_resume_reuses_csv_filepath(self, mock_analyzer, sample_images, tmp_path):
+        """On resume, the CSV from the first run is reused instead of creating a new one."""
+        state_path = str(tmp_path / ".state_test.json")
+        original_csv = str(tmp_path / "first-run.csv")
+
+        pre_state = ScanState(target="test", csv_filepath=original_csv)
+        pre_state.mark_completed("quay.example.com/testorg/java-app:17")
+        pre_state.save(state_path)
+
+        mock_analyzer.analyze_image.return_value = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=True,
+            target="test",
+        )
+        new_csv = str(tmp_path / "second-run.csv")
+        _, returned_csv, _skipped = orchestrator.analyze_images(sample_images, csv_filepath=new_csv)
+
+        assert returned_csv == original_csv
+
+    def test_csv_filepath_saved_in_state(self, mock_analyzer, sample_images, tmp_path):
+        """The CSV path is persisted in the state file."""
+        state_path = str(tmp_path / ".state_test.json")
+        csv_path = str(tmp_path / "results.csv")
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=False,
+            target="my-cluster",
+        )
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        loaded = ScanState.load(state_path)
+        assert loaded.csv_filepath == csv_path
+
     def test_clean_state_deletes_file(self, tmp_path):
         """Simulate --clean-state: the state file is removed."""
         state_path = tmp_path / ".state_test.json"

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -477,8 +477,8 @@ class TestAnalysisOrchestratorResume:
         loaded = ScanState.load(state_path)
         assert loaded.target == "ocp-prod"
 
-    def test_timed_out_image_marked_completed(self, mock_analyzer, sample_images, tmp_path):
-        """Timed-out images should be marked as completed in the state file."""
+    def test_error_image_in_error_set(self, mock_analyzer, sample_images, tmp_path):
+        """Failed images go into error_images, not completed_images."""
         state_path = str(tmp_path / ".state_test.json")
 
         def side_effect(image_name, debug=False):
@@ -498,8 +498,31 @@ class TestAnalysisOrchestratorResume:
         orchestrator.analyze_images(sample_images)
 
         loaded = ScanState.load(state_path)
-        assert loaded.is_completed("quay.example.com/testorg/java-app:17")
+        assert not loaded.is_completed("quay.example.com/testorg/java-app:17")
+        assert loaded.error_count == 1
         assert loaded.is_completed("quay.example.com/testorg/node-app:20")
+
+    def test_error_images_retried_on_resume(self, mock_analyzer, sample_images, tmp_path):
+        """Images in error_images should be retried on resume."""
+        state_path = str(tmp_path / ".state_test.json")
+        pre_state = ScanState(target="test")
+        pre_state.mark_completed("quay.example.com/testorg/node-app:20")
+        pre_state.mark_error("quay.example.com/testorg/java-app:17")
+        pre_state.save(state_path)
+
+        mock_analyzer.analyze_image.return_value = _make_java_result("quay.example.com/testorg/java-app:17")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=True,
+            target="test",
+        )
+        count, _, _skipped = orchestrator.analyze_images(sample_images)
+
+        assert count == 1
+        mock_analyzer.analyze_image.assert_called_once_with("quay.example.com/testorg/java-app:17", debug=False)
 
     def test_defensive_guard_no_state_file_path(self, mock_analyzer, sample_images):
         """state_file_path=None and resume=False must not raise errors."""
@@ -514,6 +537,44 @@ class TestAnalysisOrchestratorResume:
         count, _, _skipped = orchestrator.analyze_images(sample_images)
 
         assert count == 2
+
+    def test_resume_restores_results_into_records(self, mock_analyzer, sample_images, tmp_path):
+        """On resume, cached analysis results are restored into image dicts."""
+        state_path = str(tmp_path / ".state_test.json")
+        csv_path = str(tmp_path / "results.csv")
+
+        cached_result = {
+            "java_binary": "/usr/bin/java",
+            "java_version": "17.0.1",
+            "java_cgroup_v2_compatible": "Yes",
+            "node_binary": "None",
+            "node_version": "None",
+            "node_cgroup_v2_compatible": "N/A",
+            "dotnet_binary": "None",
+            "dotnet_version": "None",
+            "dotnet_cgroup_v2_compatible": "N/A",
+            "analysis_error": "",
+        }
+        pre_state = ScanState(target="test", csv_filepath=csv_path)
+        pre_state.mark_completed("quay.example.com/testorg/java-app:17", cached_result)
+        pre_state.save(state_path)
+
+        mock_analyzer.analyze_image.return_value = _make_node_result("quay.example.com/testorg/node-app:20")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=True,
+            target="test",
+        )
+        orchestrator.analyze_images(sample_images, csv_filepath=csv_path)
+
+        java_records = [r for r in sample_images if r["image_name"] == "quay.example.com/testorg/java-app:17"]
+        for rec in java_records:
+            assert rec["java_binary"] == "/usr/bin/java"
+            assert rec["java_version"] == "17.0.1"
+            assert rec["java_cgroup_v2_compatible"] == "Yes"
 
     def test_resume_reuses_csv_filepath(self, mock_analyzer, sample_images, tmp_path):
         """On resume, the CSV from the first run is reused instead of creating a new one."""

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -402,6 +402,7 @@ class TestAnalysisOrchestratorResume:
             pull_secret_path=".pull-secret",
             state_file_path=state_path,
             resume=True,
+            target="test",
         )
         count, _, _skipped = orchestrator.analyze_images(sample_images)
 
@@ -419,12 +420,14 @@ class TestAnalysisOrchestratorResume:
             pull_secret_path=".pull-secret",
             state_file_path=state_path,
             resume=False,
+            target="my-cluster",
         )
         orchestrator.analyze_images(sample_images)
 
         assert (tmp_path / ".state_test.json").exists()
         loaded = ScanState.load(state_path)
         assert loaded.completed_count == 2
+        assert loaded.target == "my-cluster"
 
     def test_state_file_not_written_when_path_is_none(self, mock_analyzer, sample_images, tmp_path):
         """When state_file_path is None, no state file should be created."""
@@ -450,11 +453,29 @@ class TestAnalysisOrchestratorResume:
             pull_secret_path=".pull-secret",
             state_file_path=state_path,
             resume=True,
+            target="my-cluster",
         )
         count, _, _skipped = orchestrator.analyze_images(sample_images)
 
         assert count == 2
         assert mock_analyzer.analyze_image.call_count == 2
+
+    def test_resume_missing_state_uses_real_target(self, mock_analyzer, sample_images, tmp_path):
+        """When --resume finds no state file, new state uses real target name."""
+        state_path = str(tmp_path / ".state_missing.json")
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=state_path,
+            resume=True,
+            target="ocp-prod",
+        )
+        orchestrator.analyze_images(sample_images)
+
+        loaded = ScanState.load(state_path)
+        assert loaded.target == "ocp-prod"
 
     def test_timed_out_image_marked_completed(self, mock_analyzer, sample_images, tmp_path):
         """Timed-out images should be marked as completed in the state file."""
@@ -472,12 +493,27 @@ class TestAnalysisOrchestratorResume:
             pull_secret_path=".pull-secret",
             state_file_path=state_path,
             resume=False,
+            target="test",
         )
         orchestrator.analyze_images(sample_images)
 
         loaded = ScanState.load(state_path)
         assert loaded.is_completed("quay.example.com/testorg/java-app:17")
         assert loaded.is_completed("quay.example.com/testorg/node-app:20")
+
+    def test_defensive_guard_no_state_file_path(self, mock_analyzer, sample_images):
+        """state_file_path=None and resume=False must not raise errors."""
+        mock_analyzer.analyze_image.return_value = ImageAnalysisResult(image_name="test", image_id="")
+
+        orchestrator = AnalysisOrchestrator(
+            rootfs_path="/tmp/rootfs",
+            pull_secret_path=".pull-secret",
+            state_file_path=None,
+            resume=False,
+        )
+        count, _, _skipped = orchestrator.analyze_images(sample_images)
+
+        assert count == 2
 
     def test_clean_state_deletes_file(self, tmp_path):
         """Simulate --clean-state: the state file is removed."""

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -831,3 +831,50 @@ class TestOpenShiftModeNotBroken:
         assert result == 0
         for img in mock_collector.images:
             img.to_dict.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# TestCleanStateWithTarget
+# ---------------------------------------------------------------------------
+
+
+class TestCleanStateWithTarget:
+    """Test --clean-state with an explicit target name (no connection needed)."""
+
+    def test_clean_state_with_target_string_no_connection(self, tmp_path, capsys):
+        """--clean-state ocp-prod deletes the file without connecting."""
+        from src.scan_state import ScanState
+
+        state_dir = str(tmp_path)
+        state_file = tmp_path / ".state_ocp-prod.json"
+        ScanState(target="ocp-prod").save(state_file)
+        assert state_file.exists()
+
+        with (
+            patch("sys.argv", ["image-cgroupsv2-inspector", "--clean-state", "ocp-prod", "--state-dir", state_dir]),
+            patch.object(main_script, "run_system_checks", return_value=True),
+            patch.object(main_script, "print_banner"),
+            patch("dotenv.load_dotenv"),
+            patch.object(main_script, "OpenShiftClient") as mock_oc,
+        ):
+            result = main()
+
+        assert result == 0
+        assert not state_file.exists()
+        mock_oc.assert_not_called()
+        assert "State file removed" in capsys.readouterr().out
+
+    def test_clean_state_with_target_no_file(self, tmp_path, capsys):
+        """--clean-state nonexistent prints 'No state file found'."""
+        state_dir = str(tmp_path)
+
+        with (
+            patch("sys.argv", ["image-cgroupsv2-inspector", "--clean-state", "nonexistent", "--state-dir", state_dir]),
+            patch.object(main_script, "run_system_checks", return_value=True),
+            patch.object(main_script, "print_banner"),
+            patch("dotenv.load_dotenv"),
+        ):
+            result = main()
+
+        assert result == 0
+        assert "No state file found" in capsys.readouterr().out

--- a/tests/test_scan_state.py
+++ b/tests/test_scan_state.py
@@ -1,0 +1,176 @@
+"""Tests for the ScanState module."""
+
+import json
+import os
+import threading
+
+import pytest
+
+from src.scan_state import STATE_VERSION, ScanState
+
+
+class TestScanStateBasic:
+    """Creation, properties, and simple mutations."""
+
+    def test_empty_state(self):
+        state = ScanState(target="my-cluster")
+        assert state.target == "my-cluster"
+        assert state.completed_count == 0
+        assert state.version == STATE_VERSION
+
+    def test_mark_completed(self):
+        state = ScanState(target="c")
+        state.mark_completed("img1")
+        state.mark_completed("img2")
+        assert state.completed_count == 2
+        assert state.is_completed("img1")
+        assert state.is_completed("img2")
+        assert not state.is_completed("img3")
+
+    def test_mark_completed_updates_timestamp(self):
+        state = ScanState(target="c")
+        ts_before = state.updated_at
+        state.mark_completed("img1")
+        assert state.updated_at >= ts_before
+
+    def test_mark_completed_idempotent(self):
+        state = ScanState(target="c")
+        state.mark_completed("img1")
+        state.mark_completed("img1")
+        assert state.completed_count == 1
+
+    def test_is_completed_empty(self):
+        state = ScanState(target="c")
+        assert not state.is_completed("anything")
+
+
+class TestScanStateSaveLoad:
+    """Round-trip serialisation."""
+
+    def test_save_load_roundtrip(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = ScanState(target="my-cluster")
+        state.mark_completed("img-a")
+        state.mark_completed("img-b")
+        state.save(path)
+
+        loaded = ScanState.load(path)
+        assert loaded.target == "my-cluster"
+        assert loaded.completed_count == 2
+        assert loaded.is_completed("img-a")
+        assert loaded.is_completed("img-b")
+        assert loaded.version == STATE_VERSION
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "sub" / "dir" / "state.json"
+        state = ScanState(target="t")
+        state.save(path)
+        assert path.exists()
+
+    def test_save_overwrites_existing(self, tmp_path):
+        path = tmp_path / "state.json"
+        s1 = ScanState(target="t")
+        s1.mark_completed("a")
+        s1.save(path)
+
+        s2 = ScanState(target="t")
+        s2.mark_completed("b")
+        s2.save(path)
+
+        loaded = ScanState.load(path)
+        assert loaded.is_completed("b")
+        assert not loaded.is_completed("a")
+
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        state = ScanState.load(tmp_path / "nonexistent.json")
+        assert state.target == ""
+        assert state.completed_count == 0
+
+    def test_load_corrupt_file_returns_empty(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("NOT JSON {{{")
+        state = ScanState.load(path)
+        assert state.target == ""
+        assert state.completed_count == 0
+
+    def test_timestamps_preserved(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = ScanState(target="t", started_at="2026-01-01T00:00:00Z")
+        state.save(path)
+        loaded = ScanState.load(path)
+        assert loaded.started_at == "2026-01-01T00:00:00Z"
+
+    def test_saved_json_format(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = ScanState(target="my-target")
+        state.mark_completed("z-image")
+        state.mark_completed("a-image")
+        state.save(path)
+
+        data = json.loads(path.read_text())
+        assert data["version"] == STATE_VERSION
+        assert data["target"] == "my-target"
+        assert data["completed_images"] == ["a-image", "z-image"]
+        assert "started_at" in data
+        assert "updated_at" in data
+
+
+class TestScanStateAtomicWrite:
+    """Atomic write safety."""
+
+    def test_no_partial_writes(self, tmp_path):
+        """Concurrent saves should not corrupt the file."""
+        path = tmp_path / "state.json"
+        errors: list[Exception] = []
+
+        def writer(n: int):
+            try:
+                state = ScanState(target="t")
+                for i in range(20):
+                    state.mark_completed(f"thread-{n}-img-{i}")
+                    state.save(path)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        loaded = ScanState.load(path)
+        assert loaded.target == "t"
+        assert loaded.completed_count > 0
+
+    def test_temp_file_cleaned_on_error(self, tmp_path, monkeypatch):
+        """If os.replace fails, the temp file should be removed."""
+        path = tmp_path / "state.json"
+        state = ScanState(target="t")
+
+        def failing_replace(src, dst):
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+
+        with pytest.raises(OSError, match="simulated failure"):
+            state.save(path)
+
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert len(tmp_files) == 0
+
+
+class TestBuildStateFilename:
+    """State file name generation."""
+
+    def test_cluster_name(self):
+        assert ScanState.build_state_filename("ocp-prod") == ".state_ocp-prod.json"
+
+    def test_registry_host(self):
+        assert ScanState.build_state_filename("quay.example.com") == ".state_quay.example.com.json"
+
+    def test_registry_host_with_port(self):
+        assert ScanState.build_state_filename("quay.example.com:8443") == ".state_quay.example.com_8443.json"
+
+    def test_slashes_replaced(self):
+        assert ScanState.build_state_filename("a/b/c") == ".state_a_b_c.json"

--- a/tests/test_scan_state.py
+++ b/tests/test_scan_state.py
@@ -114,6 +114,36 @@ class TestScanStateSaveLoad:
         assert "started_at" in data
         assert "updated_at" in data
 
+    def test_csv_filepath_roundtrip(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = ScanState(target="t", csv_filepath="/tmp/out/scan.csv")
+        state.save(path)
+
+        loaded = ScanState.load(path)
+        assert loaded.csv_filepath == "/tmp/out/scan.csv"
+
+    def test_csv_filepath_none_by_default(self):
+        state = ScanState(target="t")
+        assert state.csv_filepath is None
+
+    def test_csv_filepath_none_from_old_state_file(self, tmp_path):
+        """State files created before csv_filepath was added should load fine."""
+        path = tmp_path / "state.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "target": "t",
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "completed_images": ["img1"],
+                }
+            )
+        )
+        loaded = ScanState.load(path)
+        assert loaded.csv_filepath is None
+        assert loaded.is_completed("img1")
+
 
 class TestScanStateAtomicWrite:
     """Atomic write safety."""

--- a/tests/test_scan_state.py
+++ b/tests/test_scan_state.py
@@ -105,12 +105,16 @@ class TestScanStateSaveLoad:
         state = ScanState(target="my-target")
         state.mark_completed("z-image")
         state.mark_completed("a-image")
+        state.mark_error("e-image")
+        state.mark_timeout("t-image")
         state.save(path)
 
         data = json.loads(path.read_text())
         assert data["version"] == STATE_VERSION
         assert data["target"] == "my-target"
         assert data["completed_images"] == ["a-image", "z-image"]
+        assert data["error_images"] == ["e-image"]
+        assert data["timeout_images"] == ["t-image"]
         assert "started_at" in data
         assert "updated_at" in data
 
@@ -143,6 +147,97 @@ class TestScanStateSaveLoad:
         loaded = ScanState.load(path)
         assert loaded.csv_filepath is None
         assert loaded.is_completed("img1")
+
+
+class TestScanStateCategories:
+    """Test error/timeout/completed categories."""
+
+    def test_mark_error(self):
+        state = ScanState(target="c")
+        state.mark_error("img1")
+        assert state.error_count == 1
+        assert not state.is_completed("img1")
+        assert state.is_scanned("img1")
+
+    def test_mark_timeout(self):
+        state = ScanState(target="c")
+        state.mark_timeout("img1")
+        assert state.timeout_count == 1
+        assert not state.is_completed("img1")
+        assert state.is_scanned("img1")
+
+    def test_mark_error_moves_from_completed(self):
+        state = ScanState(target="c")
+        state.mark_completed("img1")
+        state.mark_error("img1")
+        assert state.completed_count == 0
+        assert state.error_count == 1
+
+    def test_mark_completed_moves_from_error(self):
+        state = ScanState(target="c")
+        state.mark_error("img1")
+        state.mark_completed("img1")
+        assert state.completed_count == 1
+        assert state.error_count == 0
+
+    def test_scanned_count(self):
+        state = ScanState(target="c")
+        state.mark_completed("a")
+        state.mark_error("b")
+        state.mark_timeout("c")
+        assert state.scanned_count == 3
+
+    def test_categories_roundtrip(self, tmp_path):
+        path = tmp_path / "state.json"
+        state = ScanState(target="t")
+        state.mark_completed("ok")
+        state.mark_error("fail")
+        state.mark_timeout("slow")
+        state.save(path)
+
+        loaded = ScanState.load(path)
+        assert loaded.is_completed("ok")
+        assert not loaded.is_completed("fail")
+        assert not loaded.is_completed("slow")
+        assert loaded.is_scanned("fail")
+        assert loaded.is_scanned("slow")
+        assert loaded.error_count == 1
+        assert loaded.timeout_count == 1
+
+    def test_image_results_saved_with_completed(self, tmp_path):
+        path = tmp_path / "state.json"
+        result = {"java_binary": "/usr/bin/java", "java_version": "17.0.1"}
+        state = ScanState(target="t")
+        state.mark_completed("img1", result)
+        state.save(path)
+
+        loaded = ScanState.load(path)
+        cached = loaded.get_result("img1")
+        assert cached is not None
+        assert cached["java_binary"] == "/usr/bin/java"
+
+    def test_get_result_returns_none_for_unknown(self):
+        state = ScanState(target="t")
+        assert state.get_result("nonexistent") is None
+
+    def test_v1_state_file_loads_as_completed(self, tmp_path):
+        """v1 state files (no error/timeout) should load without errors."""
+        path = tmp_path / "state.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "target": "t",
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "completed_images": ["img1", "img2"],
+                }
+            )
+        )
+        loaded = ScanState.load(path)
+        assert loaded.is_completed("img1")
+        assert loaded.error_count == 0
+        assert loaded.timeout_count == 0
 
 
 class TestScanStateAtomicWrite:


### PR DESCRIPTION
Implement a JSON state file that tracks which images have been scanned, so large cluster scans interrupted mid-way can be resumed without re-processing already-completed images.