### PR TITLE
Add deep-scan test images to Quay setup/teardown scripts

### DIFF
--- a/manifests/quay/deep-scan-images/binary-cgv1/Containerfile
+++ b/manifests/quay/deep-scan-images/binary-cgv1/Containerfile
@@ -1,0 +1,8 @@
+FROM docker.io/library/golang:1.22-alpine AS builder
+WORKDIR /src
+COPY main.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /cgroup-reader main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /cgroup-reader /usr/local/bin/cgroup-reader
+ENTRYPOINT ["/usr/local/bin/cgroup-reader"]

--- a/manifests/quay/deep-scan-images/binary-cgv1/Containerfile
+++ b/manifests/quay/deep-scan-images/binary-cgv1/Containerfile
@@ -1,8 +1,10 @@
 FROM docker.io/library/golang:1.22-alpine AS builder
 WORKDIR /src
+COPY go.mod .
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /cgroup-reader main.go
 
 FROM registry.access.redhat.com/ubi9-minimal:latest
 COPY --from=builder /cgroup-reader /usr/local/bin/cgroup-reader
 ENTRYPOINT ["/usr/local/bin/cgroup-reader"]
+CMD ["--help"]

--- a/manifests/quay/deep-scan-images/binary-cgv1/go.mod
+++ b/manifests/quay/deep-scan-images/binary-cgv1/go.mod
@@ -1,0 +1,3 @@
+module cgroup-reader
+
+go 1.22

--- a/manifests/quay/deep-scan-images/binary-cgv1/main.go
+++ b/manifests/quay/deep-scan-images/binary-cgv1/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	cgroupV1MemoryLimit = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	cgroupV1MemoryUsage = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+	cgroupV1CPUQuota    = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+	cgroupV1CPUPeriod   = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+	cgroupV1CPUShares   = "/sys/fs/cgroup/cpu/cpu.shares"
+	cgroupV1CPUAcct     = "/sys/fs/cgroup/cpuacct/cpuacct.usage"
+)
+
+func readCgroupFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "unavailable"
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func main() {
+	fmt.Printf("Memory limit: %s\n", readCgroupFile(cgroupV1MemoryLimit))
+	fmt.Printf("Memory usage: %s\n", readCgroupFile(cgroupV1MemoryUsage))
+	fmt.Printf("CPU quota: %s\n", readCgroupFile(cgroupV1CPUQuota))
+	fmt.Printf("CPU period: %s\n", readCgroupFile(cgroupV1CPUPeriod))
+	fmt.Printf("CPU shares: %s\n", readCgroupFile(cgroupV1CPUShares))
+	fmt.Printf("CPU accounting: %s\n", readCgroupFile(cgroupV1CPUAcct))
+}

--- a/manifests/quay/deep-scan-images/entrypoint-cgv1/Containerfile
+++ b/manifests/quay/deep-scan-images/entrypoint-cgv1/Containerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY entrypoint-cgv1.sh /usr/local/bin/entrypoint-cgv1.sh
+RUN chmod +x /usr/local/bin/entrypoint-cgv1.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint-cgv1.sh"]
+CMD ["/bin/bash", "-c", "echo running"]

--- a/manifests/quay/deep-scan-images/entrypoint-cgv1/entrypoint-cgv1.sh
+++ b/manifests/quay/deep-scan-images/entrypoint-cgv1/entrypoint-cgv1.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This entrypoint reads cgroup v1 paths for memory tuning
+MEM_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "0")
+CPU_QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null || echo "-1")
+CPU_PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null || echo "100000")
+CPU_SHARES=$(cat /sys/fs/cgroup/cpu/cpu.shares 2>/dev/null || echo "1024")
+
+echo "Memory limit: ${MEM_LIMIT}"
+echo "CPU quota: ${CPU_QUOTA}/${CPU_PERIOD}"
+echo "CPU shares: ${CPU_SHARES}"
+
+exec "$@"

--- a/manifests/quay/deep-scan-images/source-cgv1/Containerfile
+++ b/manifests/quay/deep-scan-images/source-cgv1/Containerfile
@@ -1,0 +1,6 @@
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY cgroup-helpers.sh /opt/app/cgroup-helpers.sh
+COPY entrypoint-source.sh /opt/app/entrypoint-source.sh
+RUN chmod +x /opt/app/cgroup-helpers.sh /opt/app/entrypoint-source.sh
+ENTRYPOINT ["/opt/app/entrypoint-source.sh"]
+CMD ["/bin/bash", "-c", "echo running"]

--- a/manifests/quay/deep-scan-images/source-cgv1/cgroup-helpers.sh
+++ b/manifests/quay/deep-scan-images/source-cgv1/cgroup-helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Helper library for cgroup resource detection
+get_memory_limit() {
+    local limit
+    limit=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+    if [[ -z "$limit" ]] || [[ "$limit" -eq 9223372036854771712 ]]; then
+        echo "unlimited"
+    else
+        echo "$limit"
+    fi
+}
+
+get_cpu_quota() {
+    local quota period
+    quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null || echo "-1")
+    period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null || echo "100000")
+    echo "${quota}/${period}"
+}
+
+get_cpuacct_usage() {
+    cat /sys/fs/cgroup/cpuacct/cpuacct.usage 2>/dev/null || echo "0"
+}
+
+get_blkio_weight() {
+    cat /sys/fs/cgroup/blkio/blkio.weight 2>/dev/null || echo "500"
+}

--- a/manifests/quay/deep-scan-images/source-cgv1/entrypoint-source.sh
+++ b/manifests/quay/deep-scan-images/source-cgv1/entrypoint-source.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Entrypoint that sources a helper library
+SCRIPT_DIR=$(dirname "$0")
+source "${SCRIPT_DIR}/cgroup-helpers.sh"
+
+echo "Memory: $(get_memory_limit)"
+echo "CPU: $(get_cpu_quota)"
+
+exec "$@"

--- a/manifests/quay/quay-setup.sh
+++ b/manifests/quay/quay-setup.sh
@@ -34,6 +34,8 @@
 ###############################################################################
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # ---------------------------------------------------------------------------
 # Color helpers
 # ---------------------------------------------------------------------------
@@ -311,6 +313,67 @@ add_tag() {
 }
 
 # ---------------------------------------------------------------------------
+# Build → Tag → Push (for custom Containerfile-based images)
+# ---------------------------------------------------------------------------
+build_and_push() {
+    local context_dir="$1"
+    local containerfile_name="$2"
+    local repo="$3"
+    local tag="$4"
+
+    local host
+    host=$(registry_host)
+    local local_image="${repo}:${tag}"
+    local target="${host}/${ORG}/${repo}:${tag}"
+
+    info "Processing ${target} (build from ${context_dir}/${containerfile_name})"
+
+    # Build
+    info "  Building ${local_image} ..."
+    if ! podman build \
+        -t "$local_image" \
+        -f "${context_dir}/${containerfile_name}" \
+        --tls-verify="$TLS_VERIFY" \
+        "$context_dir" 2>&1; then
+        error "  Failed to build ${local_image}"
+        PUSH_FAIL=$((PUSH_FAIL + 1))
+        FAILED_IMAGES+=("${target} (build failed)")
+        return 1
+    fi
+
+    # Tag
+    info "  Tagging as ${target} ..."
+    if ! podman tag "$local_image" "$target" 2>&1; then
+        error "  Failed to tag ${local_image} -> ${target}"
+        PUSH_FAIL=$((PUSH_FAIL + 1))
+        FAILED_IMAGES+=("${target} (tag failed)")
+        return 1
+    fi
+
+    # Push (with retry)
+    local attempt
+    for attempt in $(seq 1 "$MAX_RETRIES"); do
+        info "  Pushing ${target} (attempt ${attempt}/${MAX_RETRIES}) ..."
+        if podman push "$target" --tls-verify="$TLS_VERIFY" 2>&1; then
+            success "  Pushed ${target}"
+            PUSH_SUCCESS=$((PUSH_SUCCESS + 1))
+            # Clean up local build image to avoid filling disk
+            podman rmi "$local_image" 2>/dev/null || true
+            return 0
+        fi
+        if [[ $attempt -lt $MAX_RETRIES ]]; then
+            warn "  Push failed, retrying in ${RETRY_DELAY}s ..."
+            sleep "$RETRY_DELAY"
+        fi
+    done
+
+    error "  Failed to push ${target} after ${MAX_RETRIES} attempts"
+    PUSH_FAIL=$((PUSH_FAIL + 1))
+    FAILED_IMAGES+=("${target} (push failed)")
+    return 1
+}
+
+# ---------------------------------------------------------------------------
 # Push all test images
 # ---------------------------------------------------------------------------
 push_test_images() {
@@ -372,6 +435,68 @@ push_test_images() {
     pull_tag_push "registry.access.redhat.com/ubi9-minimal:latest" \
         "no-runtime" "latest" || true
     add_tag "no-runtime" "latest" "9-${DATE_TAG}" || true
+    echo ""
+
+    # ================================================================
+    # Deep-scan test images (--deep-scan heuristic analysis)
+    # ================================================================
+    echo ""
+    info "================================================================"
+    info "  Deep-scan test images (--deep-scan heuristic analysis)"
+    info "================================================================"
+    echo ""
+
+    # --- deep-scan-entrypoint-cgv1 (built from Containerfile) ---
+    info "=== deep-scan-entrypoint-cgv1 (entrypoint with cgroup v1 paths) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/entrypoint-cgv1" \
+        "Containerfile" "deep-scan-entrypoint-cgv1" "latest" || true
+    add_tag "deep-scan-entrypoint-cgv1" "latest" "v1.0-${DATE_TAG}" || true
+    echo ""
+
+    # --- deep-scan-source-cgv1 (built from Containerfile) ---
+    info "=== deep-scan-source-cgv1 (sourced scripts with cgroup v1 paths) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/source-cgv1" \
+        "Containerfile" "deep-scan-source-cgv1" "latest" || true
+    add_tag "deep-scan-source-cgv1" "latest" "v1.0-${DATE_TAG}" || true
+    echo ""
+
+    # --- deep-scan-binary-cgv1 (built from Containerfile, multi-stage Go) ---
+    info "=== deep-scan-binary-cgv1 (Go binary with cgroup v1 strings) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/binary-cgv1" \
+        "Containerfile" "deep-scan-binary-cgv1" "latest" || true
+    add_tag "deep-scan-binary-cgv1" "latest" "v1.0-${DATE_TAG}" || true
+    echo ""
+
+    # --- deep-scan-cadvisor (upstream, cgroup v1 positive) ---
+    info "=== deep-scan-cadvisor (cAdvisor v0.44.0, cgroup v1 positive) ==="
+    pull_tag_push "gcr.io/cadvisor/cadvisor:v0.44.0" \
+        "deep-scan-cadvisor" "v0.44.0" || true
+    add_tag "deep-scan-cadvisor" "v0.44.0" "v0.44.0-${DATE_TAG}" || true
+    add_tag "deep-scan-cadvisor" "v0.44.0" "latest" || true
+    echo ""
+
+    # --- deep-scan-node-exporter (upstream, cgroup v1 positive) ---
+    info "=== deep-scan-node-exporter (Prometheus node-exporter v1.3.1, cgroup v1 positive) ==="
+    pull_tag_push "docker.io/prom/node-exporter:v1.3.1" \
+        "deep-scan-node-exporter" "v1.3.1" || true
+    add_tag "deep-scan-node-exporter" "v1.3.1" "v1.3.1-${DATE_TAG}" || true
+    add_tag "deep-scan-node-exporter" "v1.3.1" "latest" || true
+    echo ""
+
+    # --- deep-scan-nginx-negative (upstream, negative control) ---
+    info "=== deep-scan-nginx-negative (nginx 1.25-alpine, negative control) ==="
+    pull_tag_push "docker.io/library/nginx:1.25-alpine" \
+        "deep-scan-nginx-negative" "1.25" || true
+    add_tag "deep-scan-nginx-negative" "1.25" "1.25-${DATE_TAG}" || true
+    add_tag "deep-scan-nginx-negative" "1.25" "latest" || true
+    echo ""
+
+    # --- deep-scan-redis-negative (upstream, negative control) ---
+    info "=== deep-scan-redis-negative (redis 7-alpine, negative control) ==="
+    pull_tag_push "docker.io/library/redis:7-alpine" \
+        "deep-scan-redis-negative" "7" || true
+    add_tag "deep-scan-redis-negative" "7" "7-${DATE_TAG}" || true
+    add_tag "deep-scan-redis-negative" "7" "latest" || true
     echo ""
 }
 

--- a/manifests/quay/quay-setup.sh
+++ b/manifests/quay/quay-setup.sh
@@ -357,8 +357,6 @@ build_and_push() {
         if podman push "$target" --tls-verify="$TLS_VERIFY" 2>&1; then
             success "  Pushed ${target}"
             PUSH_SUCCESS=$((PUSH_SUCCESS + 1))
-            # Clean up local build image to avoid filling disk
-            podman rmi "$local_image" 2>/dev/null || true
             return 0
         fi
         if [[ $attempt -lt $MAX_RETRIES ]]; then
@@ -451,6 +449,7 @@ push_test_images() {
     build_and_push "${SCRIPT_DIR}/deep-scan-images/entrypoint-cgv1" \
         "Containerfile" "deep-scan-entrypoint-cgv1" "latest" || true
     add_tag "deep-scan-entrypoint-cgv1" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-entrypoint-cgv1:latest" 2>/dev/null || true
     echo ""
 
     # --- deep-scan-source-cgv1 (built from Containerfile) ---
@@ -458,6 +457,7 @@ push_test_images() {
     build_and_push "${SCRIPT_DIR}/deep-scan-images/source-cgv1" \
         "Containerfile" "deep-scan-source-cgv1" "latest" || true
     add_tag "deep-scan-source-cgv1" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-source-cgv1:latest" 2>/dev/null || true
     echo ""
 
     # --- deep-scan-binary-cgv1 (built from Containerfile, multi-stage Go) ---
@@ -465,6 +465,7 @@ push_test_images() {
     build_and_push "${SCRIPT_DIR}/deep-scan-images/binary-cgv1" \
         "Containerfile" "deep-scan-binary-cgv1" "latest" || true
     add_tag "deep-scan-binary-cgv1" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-binary-cgv1:latest" 2>/dev/null || true
     echo ""
 
     # --- deep-scan-cadvisor (upstream, cgroup v1 positive) ---

--- a/manifests/quay/quay-teardown.sh
+++ b/manifests/quay/quay-teardown.sh
@@ -62,6 +62,13 @@ TEST_REPOS=(
     dotnet-compatible
     dotnet-incompatible
     no-runtime
+    deep-scan-entrypoint-cgv1
+    deep-scan-source-cgv1
+    deep-scan-binary-cgv1
+    deep-scan-cadvisor
+    deep-scan-node-exporter
+    deep-scan-nginx-negative
+    deep-scan-redis-negative
 )
 
 # ---------------------------------------------------------------------------
@@ -229,6 +236,10 @@ cleanup_local_images() {
         "mcr.microsoft.com/dotnet/runtime:8.0"
         "mcr.microsoft.com/dotnet/core/runtime:3.0"
         "registry.access.redhat.com/ubi9-minimal:latest"
+        "gcr.io/cadvisor/cadvisor:v0.44.0"
+        "docker.io/prom/node-exporter:v1.3.1"
+        "docker.io/library/nginx:1.25-alpine"
+        "docker.io/library/redis:7-alpine"
     )
 
     info "Cleaning up upstream images ..."
@@ -238,6 +249,18 @@ cleanup_local_images() {
             podman rmi "$img" 2>/dev/null || warn "  Could not remove ${img}"
         fi
     done
+
+    # Clean up locally built deep-scan images
+    info "Cleaning up locally built deep-scan images ..."
+    local deep_scan_local
+    deep_scan_local=$(podman images --format "{{.Repository}}:{{.Tag}}" \
+        | grep -E "^(localhost/)?deep-scan-" 2>/dev/null || true)
+    if [[ -n "$deep_scan_local" ]]; then
+        while IFS= read -r img; do
+            info "  Removing local build image ${img} ..."
+            podman rmi "$img" 2>/dev/null || warn "  Could not remove ${img}"
+        done <<< "$deep_scan_local"
+    fi
 
     success "Local image cleanup complete."
     echo ""


### PR DESCRIPTION
Support the new --deep-scan feature (issue #28) by adding 7 test images: 3 custom-built (entrypoint, sourced script, Go binary with cgroupv1 refs) and 4 upstream (cadvisor, node-exporter, nginx/redis as negative controls).