### PR TITLE
feat: add --deep-scan flag, CSV columns, and cgroup v1 pattern registry

### DIFF
--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -143,6 +143,15 @@ The tool will save credentials to .env file after successful connection.
     )
 
     parser.add_argument(
+        "--deep-scan",
+        dest="deep_scan",
+        action="store_true",
+        default=False,
+        help="Enable heuristic deep-scan for cgroup v1 references in entrypoint scripts "
+        "and binaries. Requires --analyze. Results appear in deep_scan_* CSV columns.",
+    )
+
+    parser.add_argument(
         "--pull-secret",
         dest="pull_secret",
         type=str,
@@ -415,6 +424,18 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
         print(f"        ✗ cgroup v2 incompatible: {dotnet_incompat}")
         if dotnet_unknown > 0:
             print(f"        ? cgroup v2 unknown: {dotnet_unknown}")
+    deep_scan_found = sum(1 for img in images if img.get("deep_scan_match") == "true")
+    if deep_scan_found > 0 or any(img.get("deep_scan_match") != "" for img in images):
+        print(f"      Deep-scan matches: {deep_scan_found} images with cgroup v1 references")
+        high = sum(1 for img in images if img.get("deep_scan_confidence") == "high")
+        medium = sum(1 for img in images if img.get("deep_scan_confidence") == "medium")
+        low = sum(1 for img in images if img.get("deep_scan_confidence") == "low")
+        if high:
+            print(f"        ⚠ high confidence: {high}")
+        if medium:
+            print(f"        ⚠ medium confidence: {medium}")
+        if low:
+            print(f"        ⚠ low confidence: {low}")
     skipped_count = len(skipped_images) if skipped_images else 0
     print(f"      Images skipped (timeout): {skipped_count}")
 
@@ -576,6 +597,12 @@ def main() -> int:
                     logger.warning("No images found in the registry")
                 return 0
 
+            if args.deep_scan and not args.analyze:
+                print("\n✗ Error: --deep-scan requires --analyze to be specified.")
+                if log_to_file:
+                    logger.error("--deep-scan requires --analyze")
+                return 1
+
             if args.analyze:
                 if not args.rootfs_path:
                     print("\n✗ Error: --analyze requires --rootfs-path.")
@@ -617,6 +644,7 @@ def main() -> int:
                     state_file_path=state_file_path,
                     resume=args.resume,
                     target=registry_host,
+                    deep_scan=args.deep_scan,
                 )
                 _, csv_path, skipped = orchestrator.analyze_images(
                     images=images,
@@ -740,6 +768,12 @@ def main() -> int:
                 logger.warning("No containers found in the cluster")
             return 0
 
+        if args.deep_scan and not args.analyze:
+            print("\n✗ Error: --deep-scan requires --analyze to be specified.")
+            if log_to_file:
+                logger.error("--deep-scan requires --analyze")
+            return 1
+
         if args.analyze:
             if not args.rootfs_path:
                 print("\n✗ Error: --analyze requires --rootfs-path to be specified.")
@@ -791,6 +825,7 @@ def main() -> int:
                 state_file_path=state_file_path,
                 resume=args.resume,
                 target=client.cluster_name,
+                deep_scan=args.deep_scan,
             )
             _, csv_path, skipped = orchestrator.analyze_images(
                 images=image_dicts,

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -58,6 +58,7 @@ class AnalysisOrchestrator:
         state_file_path: str | None = None,
         resume: bool = False,
         target: str = "",
+        deep_scan: bool = False,
     ) -> None:
         self.rootfs_path = rootfs_path
         self.pull_secret_path = pull_secret_path
@@ -67,6 +68,7 @@ class AnalysisOrchestrator:
         self.state_file_path = state_file_path
         self.resume = resume
         self.target = target
+        self.deep_scan = deep_scan
 
     def _save_csv(self, images: list[dict], filepath: str) -> None:
         """Write image records to CSV using the unified schema."""
@@ -112,6 +114,7 @@ class AnalysisOrchestrator:
             self.pull_secret_path,
             self.internal_registry_route,
             self.openshift_token,
+            deep_scan=self.deep_scan,
         )
 
         unique_image_names: list[str] = []
@@ -293,3 +296,7 @@ class AnalysisOrchestrator:
                 record["dotnet_version"] = result.dotnet_versions
                 record["dotnet_cgroup_v2_compatible"] = result.dotnet_compatible
                 record["analysis_error"] = result.error or ""
+                record["deep_scan_match"] = result.deep_scan_match
+                record["deep_scan_confidence"] = result.deep_scan_confidence
+                record["deep_scan_sources"] = result.deep_scan_sources
+                record["deep_scan_patterns"] = result.deep_scan_patterns

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -1,0 +1,127 @@
+"""
+Deep Scan Module
+================
+
+Heuristic detection of cgroup v1 references in container images.
+Scans entrypoint scripts, sourced scripts, and binaries for patterns
+that indicate the image may not work correctly on cgroup v2 systems.
+
+Confidence levels:
+- high:   pattern found directly in the ENTRYPOINT/CMD script
+- medium: pattern found in a script sourced/executed by the entrypoint
+- low:    pattern found via `strings` on a binary
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Cgroup v1 controller paths (directories under /sys/fs/cgroup/)
+# These directories exist ONLY in cgroup v1 and NOT in unified cgroup v2.
+# ---------------------------------------------------------------------------
+CGROUPV1_CONTROLLER_DIRS = (
+    "/sys/fs/cgroup/memory/",
+    "/sys/fs/cgroup/cpu/",
+    "/sys/fs/cgroup/cpuacct/",
+    "/sys/fs/cgroup/blkio/",
+    "/sys/fs/cgroup/devices/",
+    "/sys/fs/cgroup/freezer/",
+    "/sys/fs/cgroup/net_cls/",
+    "/sys/fs/cgroup/net_prio/",
+    "/sys/fs/cgroup/perf_event/",
+    "/sys/fs/cgroup/hugetlb/",
+    "/sys/fs/cgroup/pids/",
+    "/sys/fs/cgroup/rdma/",
+    "/sys/fs/cgroup/cpu,cpuacct/",
+    "/sys/fs/cgroup/net_cls,net_prio/",
+)
+
+# ---------------------------------------------------------------------------
+# Cgroup v1 control files — names that are exclusive to v1.
+# These file names do NOT exist under the cgroup v2 unified hierarchy.
+# ---------------------------------------------------------------------------
+CGROUPV1_FILE_NAMES = (
+    # Memory controller (v1)
+    "memory.limit_in_bytes",
+    "memory.usage_in_bytes",
+    "memory.max_usage_in_bytes",
+    "memory.soft_limit_in_bytes",
+    "memory.failcnt",
+    "memory.memsw.limit_in_bytes",
+    "memory.memsw.usage_in_bytes",
+    "memory.kmem.limit_in_bytes",
+    "memory.kmem.usage_in_bytes",
+    # CPU controller (v1)
+    "cpu.cfs_quota_us",
+    "cpu.cfs_period_us",
+    "cpu.shares",
+    "cpu.rt_runtime_us",
+    "cpu.rt_period_us",
+    # CPU accounting (v1 only — merged into cpu in v2)
+    "cpuacct.usage",
+    "cpuacct.usage_percpu",
+    "cpuacct.stat",
+    # Block I/O (v1 name; v2 uses "io")
+    "blkio.weight",
+    "blkio.throttle.read_bps_device",
+    "blkio.throttle.write_bps_device",
+    "blkio.throttle.read_iops_device",
+    "blkio.throttle.write_iops_device",
+)
+
+# ---------------------------------------------------------------------------
+# Compiled regex that matches ANY of the above patterns in a text line.
+# Used by the scan functions to test whether a line contains a v1 reference.
+# ---------------------------------------------------------------------------
+_PATTERN_STRINGS = list(CGROUPV1_CONTROLLER_DIRS) + list(CGROUPV1_FILE_NAMES)
+
+# Sort longest-first so that e.g. "/sys/fs/cgroup/cpu,cpuacct/" matches
+# before "/sys/fs/cgroup/cpu/".
+_PATTERN_STRINGS.sort(key=len, reverse=True)
+CGROUPV1_REGEX = re.compile("|".join(re.escape(p) for p in _PATTERN_STRINGS))
+
+
+def find_cgroupv1_patterns(text: str) -> list[str]:
+    """Return de-duplicated cgroup v1 patterns found in *text*.
+
+    Args:
+        text: Content to scan (file content, strings output, etc.)
+
+    Returns:
+        List of unique matched pattern strings, in order of first occurrence.
+    """
+    seen: dict[str, None] = {}
+    for match in CGROUPV1_REGEX.finditer(text):
+        pattern = match.group(0)
+        if pattern not in seen:
+            seen[pattern] = None
+    return list(seen)
+
+
+def run_deep_scan(
+    extract_path: Path,
+    image_name: str,
+    debug: bool = False,
+) -> list:
+    """Run all deep-scan heuristics on an extracted container rootfs.
+
+    This is the main entry point called by ImageAnalyzer when --deep-scan
+    is enabled. Currently returns an empty list; steps 3 and 4 will add
+    the actual entrypoint and binary scanning logic.
+
+    Args:
+        extract_path: Path to the extracted container rootfs.
+        image_name: Image name (for debug logging).
+        debug: Enable debug output.
+
+    Returns:
+        List of DeepScanMatch objects (from image_analyzer module).
+    """
+    if debug:
+        print(f"      [DEBUG] Deep scan enabled for {image_name}")
+        print(f"      [DEBUG] Extract path: {extract_path}")
+        print(f"      [DEBUG] Loaded {len(_PATTERN_STRINGS)} cgroup v1 patterns")
+    return []

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -31,6 +31,15 @@ class BinaryInfo:
 
 
 @dataclass
+class DeepScanMatch:
+    """A single cgroup v1 heuristic match."""
+
+    source: str          # file where the match was found, e.g. "/entrypoint.sh"
+    pattern: str         # the cgroup v1 pattern matched, e.g. "memory.limit_in_bytes"
+    confidence: str      # "high", "medium", or "low"
+
+
+@dataclass
 class ImageAnalysisResult:
     """Result of analyzing a container image."""
 
@@ -39,6 +48,7 @@ class ImageAnalysisResult:
     java_binaries: list[BinaryInfo] = field(default_factory=list)
     node_binaries: list[BinaryInfo] = field(default_factory=list)
     dotnet_binaries: list[BinaryInfo] = field(default_factory=list)
+    deep_scan_matches: list[DeepScanMatch] = field(default_factory=list)
     error: str | None = None
 
     @property
@@ -113,6 +123,44 @@ class ImageAnalysisResult:
         compatible = all(b.is_compatible for b in self.dotnet_binaries)
         return "Yes" if compatible else "No"
 
+    @property
+    def deep_scan_match(self) -> str:
+        """Return 'true' if any cgroup v1 pattern was found, 'false' otherwise, '' if not scanned."""
+        if not hasattr(self, 'deep_scan_matches') or self.deep_scan_matches is None:
+            return ""
+        return "true" if self.deep_scan_matches else "false"
+
+    @property
+    def deep_scan_confidence(self) -> str:
+        """Return the highest confidence level among all matches.
+
+        Priority: high > medium > low. Empty string if no matches or not scanned.
+        """
+        if not self.deep_scan_matches:
+            return ""
+        levels = {m.confidence for m in self.deep_scan_matches}
+        if "high" in levels:
+            return "high"
+        if "medium" in levels:
+            return "medium"
+        return "low"
+
+    @property
+    def deep_scan_sources(self) -> str:
+        """Return pipe-separated unique source files where matches were found."""
+        if not self.deep_scan_matches:
+            return ""
+        sources = dict.fromkeys(m.source for m in self.deep_scan_matches)
+        return "|".join(sources)
+
+    @property
+    def deep_scan_patterns(self) -> str:
+        """Return pipe-separated unique patterns matched."""
+        if not self.deep_scan_matches:
+            return ""
+        patterns = dict.fromkeys(m.pattern for m in self.deep_scan_matches)
+        return "|".join(patterns)
+
 
 class ImageAnalyzer:
     """
@@ -175,6 +223,7 @@ class ImageAnalyzer:
         pull_secret_path: str | None = None,
         internal_registry_route: str | None = None,
         openshift_token: str | None = None,
+        deep_scan: bool = False,
     ):
         """
         Initialize the image analyzer.
@@ -188,12 +237,14 @@ class ImageAnalyzer:
                 are rewritten to use this route so podman can pull them.
             openshift_token: Bearer token for authenticating to the internal
                 registry route via ``podman login``.
+            deep_scan: Enable heuristic deep-scan for cgroup v1 references.
         """
         self.rootfs_base = Path(rootfs_base_path).resolve()
         self.rootfs_path = self.rootfs_base / "rootfs"
         self.pull_secret_path = Path(pull_secret_path) if pull_secret_path else None
         self.internal_registry_route = internal_registry_route
         self.openshift_token = openshift_token
+        self.deep_scan = deep_scan
         self._registry_logged_in = False
 
         # Ensure rootfs directory exists
@@ -1125,6 +1176,16 @@ class ImageAnalyzer:
                         runtime_type=".NET",
                     )
                 )
+
+            # Deep scan: heuristic cgroup v1 detection
+            if self.deep_scan:
+                from .deep_scan import run_deep_scan
+                deep_matches = run_deep_scan(
+                    extract_path=extract_path,
+                    image_name=podman_image,
+                    debug=debug,
+                )
+                result.deep_scan_matches = deep_matches
 
             # Report findings
             if result.java_binaries:

--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -34,6 +34,10 @@ CSV_COLUMNS = [
     "dotnet_version",
     "dotnet_cgroup_v2_compatible",
     "analysis_error",
+    "deep_scan_match",
+    "deep_scan_confidence",
+    "deep_scan_sources",
+    "deep_scan_patterns",
 ]
 
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -15,7 +15,7 @@ import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-STATE_VERSION = 2
+STATE_VERSION = 3
 
 ANALYSIS_KEYS = (
     "java_binary",
@@ -28,6 +28,10 @@ ANALYSIS_KEYS = (
     "dotnet_version",
     "dotnet_cgroup_v2_compatible",
     "analysis_error",
+    "deep_scan_match",
+    "deep_scan_confidence",
+    "deep_scan_sources",
+    "deep_scan_patterns",
 )
 
 

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.analysis_orchestrator import AnalysisOrchestrator
-from src.image_analyzer import BinaryInfo, ImageAnalysisResult
+from src.image_analyzer import BinaryInfo, DeepScanMatch, ImageAnalysisResult
 from src.registry_collector import CSV_COLUMNS
 from src.scan_state import ScanState
 
@@ -30,6 +30,16 @@ def orchestrator():
     return AnalysisOrchestrator(
         rootfs_path="/tmp/rootfs",
         pull_secret_path=".pull-secret",
+    )
+
+
+@pytest.fixture
+def orchestrator_deep_scan():
+    """Create an AnalysisOrchestrator with deep-scan enabled."""
+    return AnalysisOrchestrator(
+        rootfs_path="/tmp/rootfs",
+        pull_secret_path=".pull-secret",
+        deep_scan=True,
     )
 
 
@@ -361,6 +371,7 @@ class TestAnalysisOrchestratorOpenShift:
                 None,
                 "registry.apps.example.com",
                 "sha256~token123",
+                deep_scan=False,
             )
 
     def test_openshift_token_passed_to_analyzer(self):
@@ -632,3 +643,37 @@ class TestAnalysisOrchestratorResume:
         """--clean-state with no existing file: no error."""
         state_path = tmp_path / ".state_missing.json"
         assert not state_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestApplyResultsDeepScan
+# ---------------------------------------------------------------------------
+
+
+class TestApplyResultsDeepScan:
+    """Tests for _apply_results with deep scan fields."""
+
+    def test_deep_scan_fields_mapped(self):
+        images = [{"image_name": "test:latest"}]
+        result = ImageAnalysisResult(
+            image_name="test:latest", image_id="abc",
+            deep_scan_matches=[
+                DeepScanMatch("/entry.sh", "memory.limit_in_bytes", "high"),
+            ],
+        )
+        cache = {"test:latest": result}
+        AnalysisOrchestrator._apply_results(images, cache)
+        assert images[0]["deep_scan_match"] == "true"
+        assert images[0]["deep_scan_confidence"] == "high"
+        assert images[0]["deep_scan_sources"] == "/entry.sh"
+        assert images[0]["deep_scan_patterns"] == "memory.limit_in_bytes"
+
+    def test_deep_scan_fields_empty_when_no_matches(self):
+        images = [{"image_name": "test:latest"}]
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        cache = {"test:latest": result}
+        AnalysisOrchestrator._apply_results(images, cache)
+        assert images[0]["deep_scan_match"] == "false"
+        assert images[0]["deep_scan_confidence"] == ""
+        assert images[0]["deep_scan_sources"] == ""
+        assert images[0]["deep_scan_patterns"] == ""

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -1,0 +1,157 @@
+"""Tests for the deep_scan module — cgroup v1 pattern registry and matching."""
+
+import pytest
+
+from src.deep_scan import (
+    CGROUPV1_CONTROLLER_DIRS,
+    CGROUPV1_FILE_NAMES,
+    CGROUPV1_REGEX,
+    find_cgroupv1_patterns,
+    run_deep_scan,
+)
+
+
+class TestCgroupV1Patterns:
+    """Verify pattern constants are well-formed."""
+
+    def test_controller_dirs_end_with_slash(self):
+        for d in CGROUPV1_CONTROLLER_DIRS:
+            assert d.endswith("/"), f"{d} should end with /"
+
+    def test_controller_dirs_start_with_sys(self):
+        for d in CGROUPV1_CONTROLLER_DIRS:
+            assert d.startswith("/sys/fs/cgroup/"), f"{d} should start with /sys/fs/cgroup/"
+
+    def test_file_names_no_slashes(self):
+        for f in CGROUPV1_FILE_NAMES:
+            assert "/" not in f, f"{f} should not contain slashes"
+
+    def test_no_duplicates_in_dirs(self):
+        assert len(CGROUPV1_CONTROLLER_DIRS) == len(set(CGROUPV1_CONTROLLER_DIRS))
+
+    def test_no_duplicates_in_files(self):
+        assert len(CGROUPV1_FILE_NAMES) == len(set(CGROUPV1_FILE_NAMES))
+
+
+class TestCgroupV1Regex:
+    """Verify the compiled regex matches expected patterns."""
+
+    @pytest.mark.parametrize("pattern", [
+        "/sys/fs/cgroup/memory/",
+        "/sys/fs/cgroup/cpu/",
+        "/sys/fs/cgroup/cpuacct/",
+        "/sys/fs/cgroup/blkio/",
+        "memory.limit_in_bytes",
+        "cpu.cfs_quota_us",
+        "cpuacct.usage",
+        "blkio.weight",
+    ])
+    def test_matches_v1_patterns(self, pattern):
+        assert CGROUPV1_REGEX.search(pattern) is not None
+
+    @pytest.mark.parametrize("text", [
+        "memory.max",           # cgroup v2
+        "cpu.max",              # cgroup v2
+        "io.max",               # cgroup v2
+        "/sys/fs/cgroup/",      # just the base dir, not v1-specific
+        "cgroup.controllers",   # cgroup v2
+        "cgroup.subtree_control",  # cgroup v2
+        "some random text",
+    ])
+    def test_does_not_match_v2_or_generic(self, text):
+        assert CGROUPV1_REGEX.search(text) is None
+
+
+class TestFindCgroupV1Patterns:
+    """Tests for find_cgroupv1_patterns()."""
+
+    def test_empty_string(self):
+        assert find_cgroupv1_patterns("") == []
+
+    def test_single_match(self):
+        text = 'cat /sys/fs/cgroup/memory/memory.limit_in_bytes'
+        result = find_cgroupv1_patterns(text)
+        assert "/sys/fs/cgroup/memory/" in result
+        assert "memory.limit_in_bytes" in result
+
+    def test_multiple_matches_deduplicated(self):
+        text = """
+        MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+        MEM2=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+        """
+        result = find_cgroupv1_patterns(text)
+        assert result.count("memory.limit_in_bytes") == 1
+        assert result.count("/sys/fs/cgroup/memory/") == 1
+
+    def test_mixed_v1_and_v2(self):
+        text = """
+        # v1 path
+        cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+        # v2 path
+        cat /sys/fs/cgroup/memory.max
+        """
+        result = find_cgroupv1_patterns(text)
+        assert "memory.limit_in_bytes" in result
+        assert "memory.max" not in result
+
+    def test_entrypoint_script_realistic(self):
+        """Simulate a real entrypoint script with cgroup v1 references."""
+        script = """#!/bin/bash
+MEM_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "0")
+CPU_QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null || echo "-1")
+CPU_PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null || echo "100000")
+CPU_SHARES=$(cat /sys/fs/cgroup/cpu/cpu.shares 2>/dev/null || echo "1024")
+exec "$@"
+"""
+        result = find_cgroupv1_patterns(script)
+        assert "memory.limit_in_bytes" in result
+        assert "cpu.cfs_quota_us" in result
+        assert "cpu.cfs_period_us" in result
+        assert "cpu.shares" in result
+        assert "/sys/fs/cgroup/memory/" in result
+        assert "/sys/fs/cgroup/cpu/" in result
+
+    def test_go_binary_strings_realistic(self):
+        """Simulate output from strings on a Go binary."""
+        strings_output = """
+/sys/fs/cgroup/memory/memory.limit_in_bytes
+/sys/fs/cgroup/memory/memory.usage_in_bytes
+/sys/fs/cgroup/cpu/cpu.cfs_quota_us
+/sys/fs/cgroup/cpu/cpu.cfs_period_us
+/sys/fs/cgroup/cpuacct/cpuacct.usage
+runtime.goexit
+"""
+        result = find_cgroupv1_patterns(strings_output)
+        assert len(result) >= 5
+
+    def test_no_false_positive_on_v2_paths(self):
+        """Ensure v2-only files don't trigger matches."""
+        v2_content = """
+cat /sys/fs/cgroup/memory.max
+cat /sys/fs/cgroup/cpu.max
+cat /sys/fs/cgroup/io.max
+cat /sys/fs/cgroup/cgroup.controllers
+"""
+        assert find_cgroupv1_patterns(v2_content) == []
+
+
+class TestRunDeepScan:
+    """Tests for run_deep_scan() skeleton."""
+
+    def test_returns_empty_list(self, tmp_path):
+        """Skeleton returns empty list (actual logic in steps 3+4)."""
+        result = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            debug=False,
+        )
+        assert result == []
+
+    def test_debug_does_not_crash(self, tmp_path):
+        """Debug mode should not raise exceptions."""
+        result = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            debug=True,
+        )
+        assert result == []

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.image_analyzer import BinaryInfo, ImageAnalysisResult, ImageAnalyzer
+from src.image_analyzer import BinaryInfo, DeepScanMatch, ImageAnalysisResult, ImageAnalyzer
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -671,3 +671,77 @@ class TestBinaryPatterns:
         assert pattern.match("/usr/bin/dotnet") is not None
         assert pattern.match("/usr/share/dotnet/dotnet") is not None
         assert pattern.match("/usr/bin/dotnet-sdk") is None
+
+
+# ---------------------------------------------------------------------------
+# Deep scan result properties
+# ---------------------------------------------------------------------------
+
+
+class TestDeepScanResult:
+    """Tests for DeepScanMatch and ImageAnalysisResult deep_scan properties."""
+
+    def test_no_matches_returns_empty_strings(self):
+        result = ImageAnalysisResult(image_name="test", image_id="abc")
+        assert result.deep_scan_match == "false"
+        assert result.deep_scan_confidence == ""
+        assert result.deep_scan_sources == ""
+        assert result.deep_scan_patterns == ""
+
+    def test_single_match(self):
+        result = ImageAnalysisResult(
+            image_name="test", image_id="abc",
+            deep_scan_matches=[
+                DeepScanMatch(
+                    source="/entrypoint.sh",
+                    pattern="memory.limit_in_bytes",
+                    confidence="high",
+                ),
+            ],
+        )
+        assert result.deep_scan_match == "true"
+        assert result.deep_scan_confidence == "high"
+        assert result.deep_scan_sources == "/entrypoint.sh"
+        assert result.deep_scan_patterns == "memory.limit_in_bytes"
+
+    def test_multiple_matches_pipe_separated(self):
+        result = ImageAnalysisResult(
+            image_name="test", image_id="abc",
+            deep_scan_matches=[
+                DeepScanMatch("/entrypoint.sh", "memory.limit_in_bytes", "high"),
+                DeepScanMatch("/entrypoint.sh", "cpu.cfs_quota_us", "high"),
+                DeepScanMatch("/opt/helpers.sh", "cpuacct.usage", "medium"),
+            ],
+        )
+        assert result.deep_scan_match == "true"
+        assert result.deep_scan_confidence == "high"
+        assert result.deep_scan_sources == "/entrypoint.sh|/opt/helpers.sh"
+        assert result.deep_scan_patterns == "memory.limit_in_bytes|cpu.cfs_quota_us|cpuacct.usage"
+
+    def test_confidence_priority(self):
+        """Highest confidence wins: high > medium > low."""
+        r1 = ImageAnalysisResult("t", "", deep_scan_matches=[
+            DeepScanMatch("bin", "p1", "low"),
+        ])
+        assert r1.deep_scan_confidence == "low"
+
+        r2 = ImageAnalysisResult("t", "", deep_scan_matches=[
+            DeepScanMatch("bin", "p1", "low"),
+            DeepScanMatch("script", "p2", "medium"),
+        ])
+        assert r2.deep_scan_confidence == "medium"
+
+        r3 = ImageAnalysisResult("t", "", deep_scan_matches=[
+            DeepScanMatch("bin", "p1", "low"),
+            DeepScanMatch("script", "p2", "medium"),
+            DeepScanMatch("entry", "p3", "high"),
+        ])
+        assert r3.deep_scan_confidence == "high"
+
+    def test_sources_deduplicated(self):
+        result = ImageAnalysisResult("t", "", deep_scan_matches=[
+            DeepScanMatch("/entry.sh", "p1", "high"),
+            DeepScanMatch("/entry.sh", "p2", "high"),
+            DeepScanMatch("/entry.sh", "p3", "high"),
+        ])
+        assert result.deep_scan_sources == "/entry.sh"


### PR DESCRIPTION
Step 1+2 of the deep-scan feature:
- Add --deep-scan CLI flag (requires --analyze, default false)
- Add DeepScanMatch dataclass and extend ImageAnalysisResult
- Extend CSV_COLUMNS and ANALYSIS_KEYS with 4 new deep_scan_* fields
- Plumb deep_scan parameter through Orchestrator → Analyzer
- Create src/deep_scan.py with cgroup v1 pattern registry and regex
- Add find_cgroupv1_patterns() for reusable pattern matching
- Add run_deep_scan() skeleton (actual scan logic in steps 3+4)
- Bump STATE_VERSION to 3
- Add comprehensive tests