### PR TITLE
feat: implement entrypoint scanning with source-chain following and v…

### DIFF
--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -436,6 +436,12 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
             print(f"        ⚠ medium confidence: {medium}")
         if low:
             print(f"        ⚠ low confidence: {low}")
+        v2_aware_count = sum(1 for img in images if img.get("deep_scan_v2_aware") == "true")
+        if v2_aware_count:
+            print(f"        ✓ v2-aware (dual v1+v2 support): {v2_aware_count}")
+        v1_only = deep_scan_found - v2_aware_count
+        if v1_only > 0:
+            print(f"        ✗ v1-only (likely incompatible): {v1_only}")
     skipped_count = len(skipped_images) if skipped_images else 0
     print(f"      Images skipped (timeout): {skipped_count}")
 

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -300,3 +300,4 @@ class AnalysisOrchestrator:
                 record["deep_scan_confidence"] = result.deep_scan_confidence
                 record["deep_scan_sources"] = result.deep_scan_sources
                 record["deep_scan_patterns"] = result.deep_scan_patterns
+                record["deep_scan_v2_aware"] = result.deep_scan_v2_aware

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -101,27 +101,336 @@ def find_cgroupv1_patterns(text: str) -> list[str]:
     return list(seen)
 
 
+# ---------------------------------------------------------------------------
+# Cgroup v2 control files — names that are exclusive to the unified hierarchy.
+# If these appear in the SAME file as v1 patterns, the code likely handles
+# both cgroup versions (v2-aware).
+# ---------------------------------------------------------------------------
+CGROUPV2_FILE_NAMES = (
+    # Unified hierarchy detection
+    "cgroup.controllers",
+    "cgroup.subtree_control",
+    "cgroup.type",
+    # Memory controller (v2)
+    "memory.max",
+    "memory.current",
+    "memory.high",
+    "memory.low",
+    "memory.min",
+    "memory.swap.max",
+    "memory.swap.current",
+    # CPU controller (v2)
+    "cpu.max",
+    "cpu.weight",
+    "cpu.pressure",
+    # I/O controller (v2 — replaces blkio)
+    "io.max",
+    "io.weight",
+    "io.pressure",
+    # PIDs controller (same name in v2 but in unified hierarchy)
+    "pids.max",
+    "pids.current",
+)
+
+CGROUPV2_CONTROLLER_PATHS = (
+    "/sys/fs/cgroup/cgroup.controllers",
+    "/sys/fs/cgroup/cgroup.subtree_control",
+)
+
+_V2_PATTERN_STRINGS = list(CGROUPV2_FILE_NAMES) + list(CGROUPV2_CONTROLLER_PATHS)
+_V2_PATTERN_STRINGS.sort(key=len, reverse=True)
+CGROUPV2_REGEX = re.compile("|".join(re.escape(p) for p in _V2_PATTERN_STRINGS))
+
+
+def find_cgroupv2_patterns(text: str) -> list[str]:
+    """Return de-duplicated cgroup v2 patterns found in *text*.
+
+    Args:
+        text: Content to scan.
+
+    Returns:
+        List of unique matched v2 pattern strings, in order of first occurrence.
+    """
+    seen: dict[str, None] = {}
+    for match in CGROUPV2_REGEX.finditer(text):
+        pattern = match.group(0)
+        if pattern not in seen:
+            seen[pattern] = None
+    return list(seen)
+
+
+# ---------------------------------------------------------------------------
+# Patterns for detecting sourced/executed scripts in shell scripts
+# ---------------------------------------------------------------------------
+_SOURCE_PATTERN = re.compile(
+    r"""(?:^|\s)(?:source|\.)\s+["']?([^\s"'#;]+)["']?""",
+    re.MULTILINE,
+)
+_EXEC_PATTERN = re.compile(
+    r"""(?:^|\s)exec\s+["']?([^\s"'#;$]+)["']?""",
+    re.MULTILINE,
+)
+
+_MAX_SOURCE_DEPTH = 5
+_MAX_SCRIPT_SIZE = 1 * 1024 * 1024  # 1 MB
+
+
+def _is_shell_script(file_path: Path) -> bool:
+    """Check if a file is likely a shell script.
+
+    A file is considered a shell script if:
+    - It has a shell-like extension (.sh, .bash), OR
+    - Its first line is a shell shebang (#!/bin/bash, #!/bin/sh, #!/usr/bin/env bash)
+    """
+    if file_path.suffix in (".sh", ".bash"):
+        return True
+    try:
+        with open(file_path, "r", errors="replace") as f:
+            first_line = f.readline(256)
+        return bool(re.match(r"^#!\s*/(?:usr/)?(?:bin/)?(?:env\s+)?(?:ba)?sh", first_line))
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _resolve_script_in_rootfs(
+    script_ref: str,
+    extract_path: Path,
+    relative_to: Path | None = None,
+) -> Path | None:
+    """Resolve a script reference to an actual file in the extracted rootfs.
+
+    Handles:
+    - Absolute paths: /usr/local/bin/entrypoint.sh → extract_path/usr/local/bin/entrypoint.sh
+    - Relative paths: ./helpers.sh → resolved relative to `relative_to` directory
+    - Paths with shell variable references like ${SCRIPT_DIR}/file.sh are resolved
+      by trying common expansions, but ultimately skipped if unresolvable.
+
+    Returns:
+        Resolved Path if the file exists and is readable, None otherwise.
+    """
+    if "$" in script_ref and not script_ref.startswith("/"):
+        return None
+
+    if script_ref.startswith("/"):
+        candidate = extract_path / script_ref.lstrip("/")
+    elif relative_to:
+        candidate = relative_to / script_ref
+    else:
+        candidate = extract_path / script_ref
+
+    try:
+        resolved = candidate.resolve()
+        if not str(resolved).startswith(str(extract_path.resolve())):
+            return None
+        if resolved.is_file():
+            return resolved
+    except (OSError, ValueError):
+        pass
+
+    return None
+
+
+def _read_script_content(file_path: Path) -> str | None:
+    """Read a script file's content, returning None if unreadable or too large."""
+    try:
+        if file_path.stat().st_size > _MAX_SCRIPT_SIZE:
+            return None
+        with open(file_path, "r", errors="replace") as f:
+            return f.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _extract_sourced_paths(content: str) -> list[str]:
+    """Extract file paths from source/. and exec statements in a shell script."""
+    paths: list[str] = []
+    for match in _SOURCE_PATTERN.finditer(content):
+        paths.append(match.group(1))
+    for match in _EXEC_PATTERN.finditer(content):
+        path = match.group(1)
+        if "/" in path:
+            paths.append(path)
+    return paths
+
+
+def scan_entrypoint_scripts(
+    extract_path: Path,
+    entrypoint_cmd: list[str],
+    debug: bool = False,
+) -> tuple[list, bool]:
+    """Scan entrypoint/CMD scripts for cgroup v1 references.
+
+    Resolves the entrypoint to a file in the extracted rootfs, scans it
+    for cgroup v1 patterns, then follows source/exec chains to scan
+    referenced scripts.
+
+    Args:
+        extract_path: Path to the extracted container rootfs.
+        entrypoint_cmd: Combined ENTRYPOINT + CMD as a list of strings
+            (e.g. ["/entrypoint.sh", "arg1"]).
+        debug: Enable debug output.
+
+    Returns:
+        Tuple of (matches, v2_aware):
+        - matches: list of DeepScanMatch objects
+        - v2_aware: True if ANY scanned file contains both v1 AND v2 patterns
+    """
+    from .image_analyzer import DeepScanMatch
+
+    matches: list[DeepScanMatch] = []
+    v2_aware = False
+    scanned_files: set[str] = set()
+
+    def _scan_script(
+        file_path: Path,
+        container_path: str,
+        confidence: str,
+        depth: int = 0,
+    ) -> None:
+        nonlocal v2_aware
+
+        real_path_str = str(file_path.resolve())
+        if real_path_str in scanned_files:
+            return
+        if depth > _MAX_SOURCE_DEPTH:
+            if debug:
+                print(f"      [DEBUG] Max source depth reached at {container_path}")
+            return
+        scanned_files.add(real_path_str)
+
+        content = _read_script_content(file_path)
+        if content is None:
+            if debug:
+                print(f"      [DEBUG] Cannot read script: {container_path}")
+            return
+
+        if debug:
+            print(f"      [DEBUG] Scanning script: {container_path} (confidence={confidence}, depth={depth})")
+
+        v1_patterns = find_cgroupv1_patterns(content)
+        if v1_patterns:
+            for pattern in v1_patterns:
+                matches.append(DeepScanMatch(
+                    source=container_path,
+                    pattern=pattern,
+                    confidence=confidence,
+                ))
+            if debug:
+                print(f"      [DEBUG]   Found {len(v1_patterns)} cgroup v1 patterns in {container_path}")
+
+            v2_patterns = find_cgroupv2_patterns(content)
+            if v2_patterns:
+                v2_aware = True
+                if debug:
+                    print(f"      [DEBUG]   Also found {len(v2_patterns)} cgroup v2 patterns → v2-aware")
+
+        sourced_paths = _extract_sourced_paths(content)
+        for sourced_ref in sourced_paths:
+            resolved = _resolve_script_in_rootfs(
+                sourced_ref,
+                extract_path,
+                relative_to=file_path.parent,
+            )
+            if resolved and _is_shell_script(resolved):
+                try:
+                    rel = resolved.relative_to(extract_path.resolve())
+                    sourced_container_path = f"/{rel}"
+                except ValueError:
+                    sourced_container_path = sourced_ref
+
+                _scan_script(
+                    resolved,
+                    sourced_container_path,
+                    confidence="medium",
+                    depth=depth + 1,
+                )
+
+    if not entrypoint_cmd:
+        if debug:
+            print("      [DEBUG] No entrypoint/cmd to scan")
+        return matches, v2_aware
+
+    entrypoint_ref = entrypoint_cmd[0]
+
+    if debug:
+        print(f"      [DEBUG] Entrypoint reference: {entrypoint_ref}")
+        print(f"      [DEBUG] Full entrypoint+cmd: {entrypoint_cmd}")
+
+    if "/" not in entrypoint_ref:
+        if debug:
+            print(f"      [DEBUG] Skipping non-path entrypoint: {entrypoint_ref}")
+        return matches, v2_aware
+
+    resolved = _resolve_script_in_rootfs(entrypoint_ref, extract_path)
+    if resolved is None:
+        if debug:
+            print(f"      [DEBUG] Could not resolve entrypoint in rootfs: {entrypoint_ref}")
+        return matches, v2_aware
+
+    if not _is_shell_script(resolved):
+        if debug:
+            print(f"      [DEBUG] Entrypoint is not a shell script: {entrypoint_ref}")
+        return matches, v2_aware
+
+    _scan_script(resolved, entrypoint_ref, confidence="high", depth=0)
+
+    for arg in entrypoint_cmd[1:]:
+        if "/" in arg and not arg.startswith("-"):
+            arg_resolved = _resolve_script_in_rootfs(arg, extract_path)
+            if arg_resolved and _is_shell_script(arg_resolved) and str(arg_resolved.resolve()) not in scanned_files:
+                _scan_script(arg_resolved, arg, confidence="high", depth=0)
+
+    return matches, v2_aware
+
+
 def run_deep_scan(
     extract_path: Path,
     image_name: str,
+    entrypoint: list[str] | None = None,
+    cmd: list[str] | None = None,
     debug: bool = False,
-) -> list:
+) -> tuple[list, bool]:
     """Run all deep-scan heuristics on an extracted container rootfs.
-
-    This is the main entry point called by ImageAnalyzer when --deep-scan
-    is enabled. Currently returns an empty list; steps 3 and 4 will add
-    the actual entrypoint and binary scanning logic.
 
     Args:
         extract_path: Path to the extracted container rootfs.
         image_name: Image name (for debug logging).
+        entrypoint: ENTRYPOINT from image config (list of strings or None).
+        cmd: CMD from image config (list of strings or None).
         debug: Enable debug output.
 
     Returns:
-        List of DeepScanMatch objects (from image_analyzer module).
+        Tuple of (matches, v2_aware):
+        - matches: list of DeepScanMatch objects
+        - v2_aware: True if any scanned source has both v1 and v2 patterns
     """
     if debug:
         print(f"      [DEBUG] Deep scan enabled for {image_name}")
         print(f"      [DEBUG] Extract path: {extract_path}")
+        print(f"      [DEBUG] ENTRYPOINT: {entrypoint}")
+        print(f"      [DEBUG] CMD: {cmd}")
         print(f"      [DEBUG] Loaded {len(_PATTERN_STRINGS)} cgroup v1 patterns")
-    return []
+
+    all_matches: list = []
+    v2_aware = False
+
+    combined: list[str] = []
+    if entrypoint:
+        combined.extend(entrypoint)
+    if cmd:
+        combined.extend(cmd)
+
+    # Step 3: Entrypoint script scanning
+    if combined:
+        script_matches, scripts_v2_aware = scan_entrypoint_scripts(
+            extract_path=extract_path,
+            entrypoint_cmd=combined,
+            debug=debug,
+        )
+        all_matches.extend(script_matches)
+        if scripts_v2_aware:
+            v2_aware = True
+
+    # Step 4 (future): Binary strings scanning will be added here
+
+    return all_matches, v2_aware

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -49,6 +49,7 @@ class ImageAnalysisResult:
     node_binaries: list[BinaryInfo] = field(default_factory=list)
     dotnet_binaries: list[BinaryInfo] = field(default_factory=list)
     deep_scan_matches: list[DeepScanMatch] = field(default_factory=list)
+    deep_scan_v2_aware_flag: bool = False
     error: str | None = None
 
     @property
@@ -160,6 +161,16 @@ class ImageAnalysisResult:
             return ""
         patterns = dict.fromkeys(m.pattern for m in self.deep_scan_matches)
         return "|".join(patterns)
+
+    @property
+    def deep_scan_v2_aware(self) -> str:
+        """Return 'true' if any scanned source contains both v1 and v2 patterns.
+
+        Empty string if no deep scan was performed or no v1 matches found.
+        """
+        if not self.deep_scan_matches:
+            return ""
+        return "true" if self.deep_scan_v2_aware_flag else "false"
 
 
 class ImageAnalyzer:
@@ -340,6 +351,53 @@ class ImageAnalyzer:
                     suffix = "/" + suffix
             return self.internal_registry_route + suffix
         return image_name
+
+    def _get_image_entrypoint(self, image_name: str, debug: bool = False) -> tuple[list[str] | None, list[str] | None]:
+        """Extract ENTRYPOINT and CMD from image metadata using podman inspect.
+
+        Args:
+            image_name: Image name (already pulled).
+            debug: Enable debug output.
+
+        Returns:
+            Tuple of (entrypoint, cmd) where each is a list of strings or None.
+        """
+        import json
+
+        entrypoint = None
+        cmd = None
+
+        exit_code, stdout, _stderr = self._run_command(
+            ["podman", "inspect", "--format", "{{json .Config.Entrypoint}}", image_name],
+            timeout=30,
+            debug=debug,
+        )
+        if exit_code == 0 and stdout.strip():
+            try:
+                parsed = json.loads(stdout.strip())
+                if isinstance(parsed, list) and parsed:
+                    entrypoint = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        exit_code, stdout, _stderr = self._run_command(
+            ["podman", "inspect", "--format", "{{json .Config.Cmd}}", image_name],
+            timeout=30,
+            debug=debug,
+        )
+        if exit_code == 0 and stdout.strip():
+            try:
+                parsed = json.loads(stdout.strip())
+                if isinstance(parsed, list) and parsed:
+                    cmd = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        if debug:
+            print(f"      [DEBUG] Image ENTRYPOINT: {entrypoint}")
+            print(f"      [DEBUG] Image CMD: {cmd}")
+
+        return entrypoint, cmd
 
     def _setup_auth(self) -> str | None:
         """
@@ -1179,13 +1237,18 @@ class ImageAnalyzer:
 
             # Deep scan: heuristic cgroup v1 detection
             if self.deep_scan:
+                print("    Running deep-scan for cgroup v1 references...")
+                entrypoint, cmd = self._get_image_entrypoint(podman_image, debug=debug)
                 from .deep_scan import run_deep_scan
-                deep_matches = run_deep_scan(
+                deep_matches, v2_aware = run_deep_scan(
                     extract_path=extract_path,
                     image_name=podman_image,
+                    entrypoint=entrypoint,
+                    cmd=cmd,
                     debug=debug,
                 )
                 result.deep_scan_matches = deep_matches
+                result.deep_scan_v2_aware_flag = v2_aware
 
             # Report findings
             if result.java_binaries:
@@ -1202,6 +1265,17 @@ class ImageAnalyzer:
                 for b in result.dotnet_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
                     print(f"      {compat} .NET: {b.version} at {b.path}")
+
+            if self.deep_scan and result.deep_scan_matches:
+                v2_note = " (v2-aware)" if result.deep_scan_v2_aware_flag else ""
+                print(f"      ⚠ Deep-scan: {len(result.deep_scan_matches)} cgroup v1 reference(s) found{v2_note}")
+                sources = dict.fromkeys(m.source for m in result.deep_scan_matches)
+                for src in sources:
+                    src_matches = [m for m in result.deep_scan_matches if m.source == src]
+                    patterns_str = ", ".join(dict.fromkeys(m.pattern for m in src_matches))
+                    print(f"        [{src_matches[0].confidence}] {src}: {patterns_str}")
+            elif self.deep_scan:
+                print("      ✓ Deep-scan: no cgroup v1 references found")
 
             if not result.java_binaries and not result.node_binaries and not result.dotnet_binaries:
                 print("      No Java, Node.js, or .NET binaries found")

--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -38,6 +38,7 @@ CSV_COLUMNS = [
     "deep_scan_confidence",
     "deep_scan_sources",
     "deep_scan_patterns",
+    "deep_scan_v2_aware",
 ]
 
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -32,6 +32,7 @@ ANALYSIS_KEYS = (
     "deep_scan_confidence",
     "deep_scan_sources",
     "deep_scan_patterns",
+    "deep_scan_v2_aware",
 )
 
 

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -660,6 +660,7 @@ class TestApplyResultsDeepScan:
             deep_scan_matches=[
                 DeepScanMatch("/entry.sh", "memory.limit_in_bytes", "high"),
             ],
+            deep_scan_v2_aware_flag=False,
         )
         cache = {"test:latest": result}
         AnalysisOrchestrator._apply_results(images, cache)
@@ -667,6 +668,7 @@ class TestApplyResultsDeepScan:
         assert images[0]["deep_scan_confidence"] == "high"
         assert images[0]["deep_scan_sources"] == "/entry.sh"
         assert images[0]["deep_scan_patterns"] == "memory.limit_in_bytes"
+        assert images[0]["deep_scan_v2_aware"] == "false"
 
     def test_deep_scan_fields_empty_when_no_matches(self):
         images = [{"image_name": "test:latest"}]
@@ -677,3 +679,4 @@ class TestApplyResultsDeepScan:
         assert images[0]["deep_scan_confidence"] == ""
         assert images[0]["deep_scan_sources"] == ""
         assert images[0]["deep_scan_patterns"] == ""
+        assert images[0]["deep_scan_v2_aware"] == ""

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -1,4 +1,6 @@
-"""Tests for the deep_scan module — cgroup v1 pattern registry and matching."""
+"""Tests for the deep_scan module — cgroup v1/v2 pattern registry and matching."""
+
+from pathlib import Path
 
 import pytest
 
@@ -6,8 +8,16 @@ from src.deep_scan import (
     CGROUPV1_CONTROLLER_DIRS,
     CGROUPV1_FILE_NAMES,
     CGROUPV1_REGEX,
+    CGROUPV2_FILE_NAMES,
+    CGROUPV2_REGEX,
     find_cgroupv1_patterns,
+    find_cgroupv2_patterns,
     run_deep_scan,
+    scan_entrypoint_scripts,
+    _is_shell_script,
+    _resolve_script_in_rootfs,
+    _extract_sourced_paths,
+    _read_script_content,
 )
 
 
@@ -135,23 +145,319 @@ cat /sys/fs/cgroup/cgroup.controllers
         assert find_cgroupv1_patterns(v2_content) == []
 
 
-class TestRunDeepScan:
-    """Tests for run_deep_scan() skeleton."""
+class TestCgroupV2Patterns:
+    """Verify v2 pattern constants and regex."""
 
-    def test_returns_empty_list(self, tmp_path):
-        """Skeleton returns empty list (actual logic in steps 3+4)."""
-        result = run_deep_scan(
+    def test_v2_file_names_no_slashes(self):
+        for f in CGROUPV2_FILE_NAMES:
+            assert "/" not in f, f"{f} should not contain slashes"
+
+    @pytest.mark.parametrize("pattern", [
+        "memory.max", "cpu.max", "io.max",
+        "cgroup.controllers", "cgroup.subtree_control",
+    ])
+    def test_matches_v2_patterns(self, pattern):
+        assert CGROUPV2_REGEX.search(pattern) is not None
+
+    @pytest.mark.parametrize("text", [
+        "memory.limit_in_bytes",  # v1
+        "cpu.cfs_quota_us",       # v1
+        "some random text",
+    ])
+    def test_does_not_match_v1(self, text):
+        assert CGROUPV2_REGEX.search(text) is None
+
+
+class TestFindCgroupV2Patterns:
+    def test_empty_string(self):
+        assert find_cgroupv2_patterns("") == []
+
+    def test_finds_v2_patterns(self):
+        text = "cat /sys/fs/cgroup/memory.max && cat /sys/fs/cgroup/cpu.max"
+        result = find_cgroupv2_patterns(text)
+        assert "memory.max" in result
+        assert "cpu.max" in result
+
+    def test_no_v1_patterns_matched(self):
+        text = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes"
+        assert find_cgroupv2_patterns(text) == []
+
+
+class TestIsShellScript:
+    def test_sh_extension(self, tmp_path):
+        f = tmp_path / "test.sh"
+        f.write_text("echo hello")
+        assert _is_shell_script(f) is True
+
+    def test_bash_shebang(self, tmp_path):
+        f = tmp_path / "entrypoint"
+        f.write_text("#!/bin/bash\necho hello")
+        assert _is_shell_script(f) is True
+
+    def test_sh_shebang(self, tmp_path):
+        f = tmp_path / "entrypoint"
+        f.write_text("#!/bin/sh\necho hello")
+        assert _is_shell_script(f) is True
+
+    def test_env_bash_shebang(self, tmp_path):
+        f = tmp_path / "entrypoint"
+        f.write_text("#!/usr/bin/env bash\necho hello")
+        assert _is_shell_script(f) is True
+
+    def test_not_shell_script(self, tmp_path):
+        f = tmp_path / "binary"
+        f.write_bytes(b"\x7fELF\x00\x00\x00")
+        assert _is_shell_script(f) is False
+
+    def test_python_script(self, tmp_path):
+        f = tmp_path / "run.py"
+        f.write_text("#!/usr/bin/env python3\nprint('hello')")
+        assert _is_shell_script(f) is False
+
+
+class TestExtractSourcedPaths:
+    def test_source_command(self):
+        content = 'source /opt/helpers.sh\necho done'
+        assert "/opt/helpers.sh" in _extract_sourced_paths(content)
+
+    def test_dot_command(self):
+        content = '. /opt/helpers.sh\necho done'
+        assert "/opt/helpers.sh" in _extract_sourced_paths(content)
+
+    def test_quoted_path(self):
+        content = 'source "/opt/my helpers.sh"'
+        result = _extract_sourced_paths(content)
+        assert len(result) >= 1
+
+    def test_exec_command(self):
+        content = 'exec /usr/local/bin/run.sh --flag'
+        assert "/usr/local/bin/run.sh" in _extract_sourced_paths(content)
+
+    def test_no_matches(self):
+        content = 'echo hello\ncat /etc/hosts'
+        assert _extract_sourced_paths(content) == []
+
+    def test_variable_in_source(self):
+        content = 'source "${SCRIPT_DIR}/helpers.sh"'
+        result = _extract_sourced_paths(content)
+        assert len(result) >= 1
+
+
+class TestResolveScriptInRootfs:
+    def test_absolute_path(self, tmp_path):
+        script = tmp_path / "usr" / "local" / "bin" / "entry.sh"
+        script.parent.mkdir(parents=True)
+        script.write_text("#!/bin/bash\necho hi")
+        resolved = _resolve_script_in_rootfs("/usr/local/bin/entry.sh", tmp_path)
+        assert resolved is not None
+        assert resolved == script.resolve()
+
+    def test_missing_file(self, tmp_path):
+        assert _resolve_script_in_rootfs("/nonexistent.sh", tmp_path) is None
+
+    def test_relative_path(self, tmp_path):
+        parent = tmp_path / "opt" / "app"
+        parent.mkdir(parents=True)
+        helper = parent / "helper.sh"
+        helper.write_text("#!/bin/bash\necho hi")
+        resolved = _resolve_script_in_rootfs("helper.sh", tmp_path, relative_to=parent)
+        assert resolved is not None
+
+    def test_path_traversal_blocked(self, tmp_path):
+        """Paths that escape the rootfs should be rejected."""
+        result = _resolve_script_in_rootfs("/../../../etc/passwd", tmp_path)
+        assert result is None
+
+    def test_shell_variable_skipped(self, tmp_path):
+        result = _resolve_script_in_rootfs("${HOME}/script.sh", tmp_path)
+        assert result is None
+
+
+class TestScanEntrypointScripts:
+    """Integration tests for scan_entrypoint_scripts()."""
+
+    def _create_script(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def test_entrypoint_with_v1_patterns(self, tmp_path):
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+exec "$@"
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        assert len(matches) > 0
+        assert any(m.pattern == "memory.limit_in_bytes" for m in matches)
+        assert all(m.confidence == "high" for m in matches)
+        assert v2_aware is False
+
+    def test_entrypoint_with_v1_and_v2_patterns(self, tmp_path):
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    MEM=$(cat /sys/fs/cgroup/memory.max)
+else
+    MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+fi
+exec "$@"
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        assert len(matches) > 0
+        assert v2_aware is True
+
+    def test_source_chain_followed(self, tmp_path):
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+source /opt/helpers.sh
+echo "Memory: $(get_mem)"
+exec "$@"
+""")
+        self._create_script(tmp_path / "opt" / "helpers.sh", """#!/bin/bash
+get_mem() {
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null
+}
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        assert len(matches) > 0
+        sourced_matches = [m for m in matches if "helpers" in m.source]
+        assert len(sourced_matches) > 0
+        assert all(m.confidence == "medium" for m in sourced_matches)
+
+    def test_no_entrypoint(self, tmp_path):
+        matches, v2_aware = scan_entrypoint_scripts(tmp_path, [], debug=False)
+        assert matches == []
+        assert v2_aware is False
+
+    def test_non_path_entrypoint(self, tmp_path):
+        """Bare command like 'python' without path should be skipped."""
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["python", "app.py"], debug=False
+        )
+        assert matches == []
+
+    def test_binary_entrypoint_skipped(self, tmp_path):
+        """ELF binary should be skipped (step 4 handles this)."""
+        binary = tmp_path / "usr" / "local" / "bin" / "myapp"
+        binary.parent.mkdir(parents=True)
+        binary.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/usr/local/bin/myapp"], debug=False
+        )
+        assert matches == []
+
+    def test_v2_aware_in_sourced_file(self, tmp_path):
+        """V2 awareness detected in a sourced file."""
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+source /opt/cgroup-lib.sh
+exec "$@"
+""")
+        self._create_script(tmp_path / "opt" / "cgroup-lib.sh", """#!/bin/bash
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    MEM=$(cat /sys/fs/cgroup/memory.max)
+else
+    MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+fi
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        assert len(matches) > 0
+        assert v2_aware is True
+
+    def test_no_v1_patterns_clean(self, tmp_path):
+        """Script with no cgroup references produces no matches."""
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+echo "Hello world"
+exec "$@"
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        assert matches == []
+        assert v2_aware is False
+
+    def test_depth_limit(self, tmp_path):
+        """Source chains deeper than _MAX_SOURCE_DEPTH are truncated."""
+        for i in range(8):
+            next_script = f"/opt/level{i+1}.sh" if i < 7 else ""
+            source_line = f"source {next_script}" if next_script else ""
+            v1_ref = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes" if i == 7 else ""
+            self._create_script(tmp_path / "opt" / f"level{i}.sh", f"""#!/bin/bash
+{source_line}
+{v1_ref}
+""")
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+source /opt/level0.sh
+""")
+        matches, _ = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        # The chain is deeper than _MAX_SOURCE_DEPTH (5), so the deepest
+        # script with v1 refs may or may not be reached depending on depth
+
+
+class TestRunDeepScan:
+    """Tests for the updated run_deep_scan()."""
+
+    def _create_script(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def test_with_entrypoint(self, tmp_path):
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+exec "$@"
+""")
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
+            entrypoint=["/entrypoint.sh"],
+            cmd=None,
             debug=False,
         )
-        assert result == []
+        assert len(matches) > 0
+        assert v2_aware is False
+
+    def test_without_entrypoint(self, tmp_path):
+        matches, v2_aware = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=None,
+            cmd=None,
+            debug=False,
+        )
+        assert matches == []
+        assert v2_aware is False
+
+    def test_v2_aware_flag(self, tmp_path):
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    cat /sys/fs/cgroup/memory.max
+else
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+fi
+""")
+        matches, v2_aware = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=["/entrypoint.sh"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert v2_aware is True
 
     def test_debug_does_not_crash(self, tmp_path):
         """Debug mode should not raise exceptions."""
-        result = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             debug=True,
         )
-        assert result == []
+        assert matches == []
+        assert v2_aware is False

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -745,3 +745,27 @@ class TestDeepScanResult:
             DeepScanMatch("/entry.sh", "p3", "high"),
         ])
         assert result.deep_scan_sources == "/entry.sh"
+
+    def test_v2_aware_property(self):
+        result = ImageAnalysisResult(
+            "t", "",
+            deep_scan_matches=[
+                DeepScanMatch("/entry.sh", "memory.limit_in_bytes", "high"),
+            ],
+            deep_scan_v2_aware_flag=True,
+        )
+        assert result.deep_scan_v2_aware == "true"
+
+    def test_v2_aware_false(self):
+        result = ImageAnalysisResult(
+            "t", "",
+            deep_scan_matches=[
+                DeepScanMatch("/entry.sh", "memory.limit_in_bytes", "high"),
+            ],
+            deep_scan_v2_aware_flag=False,
+        )
+        assert result.deep_scan_v2_aware == "false"
+
+    def test_v2_aware_empty_when_no_matches(self):
+        result = ImageAnalysisResult("t", "")
+        assert result.deep_scan_v2_aware == ""


### PR DESCRIPTION
…2 awareness

Step 3 of the deep-scan feature:
- Extract ENTRYPOINT/CMD from image via podman inspect
- Scan entrypoint shell scripts for cgroup v1 patterns (high confidence)
- Follow source/./exec chains to scan referenced scripts (medium confidence)
- Detect cgroup v2 awareness: if same file has both v1 and v2 patterns, flag as v2-aware (image likely handles both cgroup versions)
- Add cgroup v2 pattern registry (memory.max, cpu.max, cgroup.controllers, etc.)
- Add deep_scan_v2_aware CSV column and property
- Security: prevent path traversal, limit recursion depth, cap file size
- Add comprehensive tests for all new functions