### PR TITLE
feat: implement binary strings scanning for deep-scan (step 4)

### DIFF
--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -174,6 +174,21 @@ _EXEC_PATTERN = re.compile(
 _MAX_SOURCE_DEPTH = 5
 _MAX_SCRIPT_SIZE = 1 * 1024 * 1024  # 1 MB
 
+# Common interpreter paths to skip when collecting binaries for strings scan.
+# These appear in ENTRYPOINT/CMD but are never the application binary.
+_INTERPRETER_PATHS = frozenset({
+    "/bin/bash",
+    "/bin/sh",
+    "/bin/dash",
+    "/bin/zsh",
+    "/usr/bin/bash",
+    "/usr/bin/sh",
+    "/usr/bin/dash",
+    "/usr/bin/zsh",
+    "/usr/bin/env",
+    "/bin/env",
+})
+
 
 def _is_shell_script(file_path: Path) -> bool:
     """Check if a file is likely a shell script.
@@ -200,15 +215,33 @@ def _resolve_script_in_rootfs(
     """Resolve a script reference to an actual file in the extracted rootfs.
 
     Handles:
-    - Absolute paths: /usr/local/bin/entrypoint.sh → extract_path/usr/local/bin/entrypoint.sh
-    - Relative paths: ./helpers.sh → resolved relative to `relative_to` directory
-    - Paths with shell variable references like ${SCRIPT_DIR}/file.sh are resolved
-      by trying common expansions, but ultimately skipped if unresolvable.
+    - Absolute paths: /usr/local/bin/entrypoint.sh
+    - Relative paths: ./helpers.sh (resolved relative to `relative_to`)
+    - Shell variable paths: ${SCRIPT_DIR}/helpers.sh, $DIR/helpers.sh
+      → extracts the filename and tries relative resolution against
+        the directory of the sourcing script
 
     Returns:
         Resolved Path if the file exists and is readable, None otherwise.
     """
-    if "$" in script_ref and not script_ref.startswith("/"):
+    # Handle paths containing shell variables
+    if "$" in script_ref:
+        # Try to extract the filename portion after the last /
+        # e.g. "${SCRIPT_DIR}/cgroup-helpers.sh" → "cgroup-helpers.sh"
+        if "/" in script_ref:
+            filename = script_ref.rsplit("/", 1)[-1]
+            # If the filename itself contains a variable, give up
+            if "$" in filename:
+                return None
+            # Try to resolve the filename relative to the sourcing script's dir
+            if relative_to:
+                candidate = relative_to / filename
+                try:
+                    resolved = candidate.resolve()
+                    if str(resolved).startswith(str(extract_path.resolve())) and resolved.is_file():
+                        return resolved
+                except (OSError, ValueError):
+                    pass
         return None
 
     if script_ref.startswith("/"):
@@ -578,9 +611,15 @@ def run_deep_scan(
             v2_aware = True
 
     # Step 4: Binary strings scanning
+    # Scan entrypoint/cmd binaries that were NOT shell scripts
+    # Skip common interpreters (bash, sh, etc.) that are never the application
     binary_refs: list[str] = []
     for ref in combined:
         if "/" not in ref or ref.startswith("-"):
+            continue
+        if ref in _INTERPRETER_PATHS:
+            if debug:
+                print(f"      [DEBUG] Skipping interpreter binary: {ref}")
             continue
         resolved = _resolve_script_in_rootfs(ref, extract_path)
         if resolved is not None and not _is_shell_script(resolved) and _is_elf_binary(resolved):

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -241,6 +241,152 @@ def _read_script_content(file_path: Path) -> str | None:
         return None
 
 
+_MAX_BINARY_SIZE = 200 * 1024 * 1024  # 200 MB
+
+_STRINGS_MIN_LENGTH = 8
+
+
+def _is_elf_binary(file_path: Path) -> bool:
+    """Check if a file is an ELF binary by reading its magic bytes."""
+    try:
+        with open(file_path, "rb") as f:
+            magic = f.read(4)
+        return magic == b"\x7fELF"
+    except OSError:
+        return False
+
+
+def _run_strings(file_path: Path, debug: bool = False) -> str | None:
+    """Run the `strings` command on a binary file.
+
+    Args:
+        file_path: Path to the binary file.
+        debug: Enable debug output.
+
+    Returns:
+        The strings output as a single string, or None if strings fails
+        or the binary is too large.
+    """
+    import subprocess
+
+    try:
+        file_size = file_path.stat().st_size
+        if file_size > _MAX_BINARY_SIZE:
+            if debug:
+                print(f"      [DEBUG] Binary too large for strings: {file_size} bytes > {_MAX_BINARY_SIZE}")
+            return None
+        if file_size == 0:
+            return None
+    except OSError:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["strings", f"-n{_STRINGS_MIN_LENGTH}", str(file_path)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            if debug:
+                print(f"      [DEBUG] strings command failed: {result.stderr[:200]}")
+            return None
+        return result.stdout
+    except FileNotFoundError:
+        if debug:
+            print("      [DEBUG] 'strings' command not found in PATH")
+        return None
+    except subprocess.TimeoutExpired:
+        if debug:
+            print("      [DEBUG] strings command timed out")
+        return None
+    except Exception as e:
+        if debug:
+            print(f"      [DEBUG] strings error: {e}")
+        return None
+
+
+def scan_binary_strings(
+    extract_path: Path,
+    binary_refs: list[str],
+    debug: bool = False,
+) -> tuple[list, bool]:
+    """Scan binary files via `strings` for cgroup v1 references.
+
+    For each binary reference:
+    1. Resolve it in the extracted rootfs
+    2. Verify it's an ELF binary
+    3. Run `strings` on it
+    4. Check the output for cgroup v1 patterns
+    5. Check for cgroup v2 patterns (v2-awareness)
+
+    Args:
+        extract_path: Path to the extracted container rootfs.
+        binary_refs: List of container paths to check (e.g. ["/usr/bin/cadvisor"]).
+        debug: Enable debug output.
+
+    Returns:
+        Tuple of (matches, v2_aware):
+        - matches: list of DeepScanMatch objects with confidence="low"
+        - v2_aware: True if any binary contains both v1 and v2 patterns
+    """
+    from .image_analyzer import DeepScanMatch
+
+    matches: list[DeepScanMatch] = []
+    v2_aware = False
+    scanned_binaries: set[str] = set()
+
+    for binary_ref in binary_refs:
+        resolved = _resolve_script_in_rootfs(binary_ref, extract_path)
+        if resolved is None:
+            if debug:
+                print(f"      [DEBUG] Could not resolve binary in rootfs: {binary_ref}")
+            continue
+
+        real_path_str = str(resolved.resolve())
+        if real_path_str in scanned_binaries:
+            continue
+        scanned_binaries.add(real_path_str)
+
+        if not _is_elf_binary(resolved):
+            if debug:
+                print(f"      [DEBUG] Not an ELF binary, skipping: {binary_ref}")
+            continue
+
+        if debug:
+            try:
+                size_mb = resolved.stat().st_size / (1024 * 1024)
+                print(f"      [DEBUG] Running strings on binary: {binary_ref} ({size_mb:.1f} MB)")
+            except OSError:
+                print(f"      [DEBUG] Running strings on binary: {binary_ref}")
+
+        strings_output = _run_strings(resolved, debug=debug)
+        if strings_output is None:
+            continue
+
+        v1_patterns = find_cgroupv1_patterns(strings_output)
+        if v1_patterns:
+            source = f"binary:{binary_ref}"
+            for pattern in v1_patterns:
+                matches.append(DeepScanMatch(
+                    source=source,
+                    pattern=pattern,
+                    confidence="low",
+                ))
+            if debug:
+                print(f"      [DEBUG]   Found {len(v1_patterns)} cgroup v1 patterns in {binary_ref}")
+
+            v2_patterns = find_cgroupv2_patterns(strings_output)
+            if v2_patterns:
+                v2_aware = True
+                if debug:
+                    print(f"      [DEBUG]   Also found {len(v2_patterns)} cgroup v2 patterns → v2-aware")
+        elif debug:
+            print(f"      [DEBUG]   No cgroup v1 patterns found in {binary_ref}")
+
+    return matches, v2_aware
+
+
 def _extract_sourced_paths(content: str) -> list[str]:
     """Extract file paths from source/. and exec statements in a shell script."""
     paths: list[str] = []
@@ -431,6 +577,25 @@ def run_deep_scan(
         if scripts_v2_aware:
             v2_aware = True
 
-    # Step 4 (future): Binary strings scanning will be added here
+    # Step 4: Binary strings scanning
+    binary_refs: list[str] = []
+    for ref in combined:
+        if "/" not in ref or ref.startswith("-"):
+            continue
+        resolved = _resolve_script_in_rootfs(ref, extract_path)
+        if resolved is not None and not _is_shell_script(resolved) and _is_elf_binary(resolved):
+            binary_refs.append(ref)
+
+    if binary_refs:
+        if debug:
+            print(f"      [DEBUG] Binary refs to scan with strings: {binary_refs}")
+        binary_matches, binary_v2_aware = scan_binary_strings(
+            extract_path=extract_path,
+            binary_refs=binary_refs,
+            debug=debug,
+        )
+        all_matches.extend(binary_matches)
+        if binary_v2_aware:
+            v2_aware = True
 
     return all_matches, v2_aware

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -139,7 +139,15 @@ CGROUPV2_CONTROLLER_PATHS = (
 
 _V2_PATTERN_STRINGS = list(CGROUPV2_FILE_NAMES) + list(CGROUPV2_CONTROLLER_PATHS)
 _V2_PATTERN_STRINGS.sort(key=len, reverse=True)
-CGROUPV2_REGEX = re.compile("|".join(re.escape(p) for p in _V2_PATTERN_STRINGS))
+# Use negative lookbehind/lookahead to prevent matching v2 patterns
+# that are substrings of v1 patterns (e.g. "io.weight" inside "blkio.weight",
+# "memory.max" inside "memory.max_usage_in_bytes").
+CGROUPV2_REGEX = re.compile(
+    "|".join(
+        rf"(?<![a-z]){re.escape(p)}(?![a-z_])"
+        for p in _V2_PATTERN_STRINGS
+    )
+)
 
 
 def find_cgroupv2_patterns(text: str) -> list[str]:

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -170,6 +170,14 @@ class TestCgroupV2Patterns:
     def test_does_not_match_v1(self, text):
         assert CGROUPV2_REGEX.search(text) is None
 
+    @pytest.mark.parametrize("text", [
+        "blkio.weight",              # v1 — contains "io.weight" as substring
+        "memory.max_usage_in_bytes", # v1 — contains "memory.max" as substring
+    ])
+    def test_does_not_match_v1_superstrings(self, text):
+        """V2 regex must not match when the v2 pattern is embedded inside a v1 pattern."""
+        assert CGROUPV2_REGEX.search(text) is None
+
 
 class TestFindCgroupV2Patterns:
     def test_empty_string(self):
@@ -184,6 +192,40 @@ class TestFindCgroupV2Patterns:
     def test_no_v1_patterns_matched(self):
         text = "cat /sys/fs/cgroup/memory/memory.limit_in_bytes"
         assert find_cgroupv2_patterns(text) == []
+
+    def test_no_false_positive_on_blkio_weight(self):
+        """'blkio.weight' is v1 — must not trigger v2 match for 'io.weight'."""
+        text = "cat /sys/fs/cgroup/blkio/blkio.weight"
+        assert find_cgroupv2_patterns(text) == []
+
+    def test_no_false_positive_on_memory_max_usage(self):
+        """'memory.max_usage_in_bytes' is v1 — must not trigger v2 match for 'memory.max'."""
+        text = "cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes"
+        assert find_cgroupv2_patterns(text) == []
+
+    def test_real_v2_memory_max_still_matches(self):
+        """Standalone 'memory.max' (actual v2 file) must still match."""
+        text = "cat /sys/fs/cgroup/memory.max"
+        result = find_cgroupv2_patterns(text)
+        assert "memory.max" in result
+
+    def test_real_v2_io_weight_still_matches(self):
+        """Standalone 'io.weight' (actual v2 file) must still match."""
+        text = "cat /sys/fs/cgroup/io.weight"
+        result = find_cgroupv2_patterns(text)
+        assert "io.weight" in result
+
+    def test_v1_and_v2_in_same_text(self):
+        """Mixed text: only real v2 patterns should match."""
+        text = """
+        blkio.weight
+        memory.max_usage_in_bytes
+        io.weight
+        memory.max
+        """
+        result = find_cgroupv2_patterns(text)
+        assert "io.weight" in result
+        assert "memory.max" in result
 
 
 class TestIsShellScript:
@@ -428,6 +470,20 @@ exec "$@"
             tmp_path, ["/entrypoint.sh"], debug=False
         )
         assert matches == []
+        assert v2_aware is False
+
+    def test_v1_only_not_flagged_v2_aware(self, tmp_path):
+        """Script with only v1 patterns (including blkio.weight) must NOT be v2-aware."""
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)
+MEM_MAX=$(cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes 2>/dev/null)
+BLKIO=$(cat /sys/fs/cgroup/blkio/blkio.weight 2>/dev/null)
+exec "$@"
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/entrypoint.sh"], debug=False
+        )
+        assert len(matches) > 0
         assert v2_aware is False
 
     def test_source_with_variable_path(self, tmp_path):

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -271,8 +271,54 @@ class TestResolveScriptInRootfs:
         result = _resolve_script_in_rootfs("/../../../etc/passwd", tmp_path)
         assert result is None
 
-    def test_shell_variable_skipped(self, tmp_path):
+    def test_shell_variable_no_relative_to_returns_none(self, tmp_path):
+        """Variable paths without relative_to cannot be resolved."""
         result = _resolve_script_in_rootfs("${HOME}/script.sh", tmp_path)
+        assert result is None
+
+    def test_variable_with_filename_resolved_relative(self, tmp_path):
+        """${SCRIPT_DIR}/helpers.sh should resolve filename relative to relative_to."""
+        parent = tmp_path / "opt" / "app"
+        parent.mkdir(parents=True)
+        helper = parent / "cgroup-helpers.sh"
+        helper.write_text("#!/bin/bash\nget_mem() { echo 1; }")
+        resolved = _resolve_script_in_rootfs(
+            "${SCRIPT_DIR}/cgroup-helpers.sh", tmp_path, relative_to=parent
+        )
+        assert resolved is not None
+        assert resolved.name == "cgroup-helpers.sh"
+
+    def test_variable_with_filename_no_relative_to(self, tmp_path):
+        """Without relative_to, variable paths cannot be resolved."""
+        result = _resolve_script_in_rootfs("${SCRIPT_DIR}/helpers.sh", tmp_path)
+        assert result is None
+
+    def test_variable_in_filename_skipped(self, tmp_path):
+        """If the filename itself contains a variable, give up."""
+        parent = tmp_path / "opt"
+        parent.mkdir(parents=True)
+        result = _resolve_script_in_rootfs("${DIR}/${FILE}", tmp_path, relative_to=parent)
+        assert result is None
+
+    def test_dollar_sign_path_resolved(self, tmp_path):
+        """$DIR/helpers.sh (no braces) should also resolve."""
+        parent = tmp_path / "opt" / "app"
+        parent.mkdir(parents=True)
+        helper = parent / "helpers.sh"
+        helper.write_text("#!/bin/bash\necho hi")
+        resolved = _resolve_script_in_rootfs(
+            "$DIR/helpers.sh", tmp_path, relative_to=parent
+        )
+        assert resolved is not None
+        assert resolved.name == "helpers.sh"
+
+    def test_variable_path_traversal_blocked(self, tmp_path):
+        """Variable-based path should still respect rootfs boundary."""
+        parent = tmp_path / "opt"
+        parent.mkdir(parents=True)
+        result = _resolve_script_in_rootfs(
+            "${DIR}/../../etc/passwd", tmp_path, relative_to=parent
+        )
         assert result is None
 
 
@@ -383,6 +429,28 @@ exec "$@"
         )
         assert matches == []
         assert v2_aware is False
+
+    def test_source_with_variable_path(self, tmp_path):
+        """source "${SCRIPT_DIR}/file.sh" pattern should be followed."""
+        self._create_script(tmp_path / "opt" / "app" / "entrypoint-source.sh", """#!/bin/bash
+SCRIPT_DIR=$(dirname "$0")
+source "${SCRIPT_DIR}/cgroup-helpers.sh"
+echo "Memory: $(get_memory_limit)"
+exec "$@"
+""")
+        self._create_script(tmp_path / "opt" / "app" / "cgroup-helpers.sh", """#!/bin/bash
+get_memory_limit() {
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo "0"
+}
+""")
+        matches, v2_aware = scan_entrypoint_scripts(
+            tmp_path, ["/opt/app/entrypoint-source.sh"], debug=False
+        )
+        assert len(matches) > 0
+        assert any("memory.limit_in_bytes" in m.pattern for m in matches)
+        sourced_matches = [m for m in matches if "cgroup-helpers" in m.source]
+        assert len(sourced_matches) > 0
+        assert all(m.confidence == "medium" for m in sourced_matches)
 
     def test_depth_limit(self, tmp_path):
         """Source chains deeper than _MAX_SOURCE_DEPTH are truncated."""
@@ -736,3 +804,31 @@ exec "$@"
         )
         assert matches == []
         assert v2_aware is False
+
+
+class TestRunDeepScanInterpreterSkip:
+    """Test that common interpreters are skipped in binary scanning."""
+
+    def _create_script(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def test_bash_not_scanned_with_strings(self, tmp_path):
+        """CMD ['/bin/bash', '-c', '...'] should not trigger strings on /bin/bash."""
+        bash = tmp_path / "bin" / "bash"
+        bash.parent.mkdir(parents=True)
+        bash.write_bytes(b"\x7fELF" + b"\x00" * 1000)
+
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+echo hello
+exec "$@"
+""")
+        matches, _ = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=["/entrypoint.sh"],
+            cmd=["/bin/bash", "-c", "echo running"],
+            debug=False,
+        )
+        assert not any("binary:/bin/bash" in m.source for m in matches)

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -18,6 +18,9 @@ from src.deep_scan import (
     _resolve_script_in_rootfs,
     _extract_sourced_paths,
     _read_script_content,
+    _is_elf_binary,
+    _run_strings,
+    scan_binary_strings,
 )
 
 
@@ -458,6 +461,278 @@ fi
             extract_path=tmp_path,
             image_name="test:latest",
             debug=True,
+        )
+        assert matches == []
+        assert v2_aware is False
+
+
+class TestIsElfBinary:
+    def test_elf_binary(self, tmp_path):
+        binary = tmp_path / "myapp"
+        binary.write_bytes(b"\x7fELF" + b"\x02\x01\x01\x00" * 100)
+        assert _is_elf_binary(binary) is True
+
+    def test_shell_script(self, tmp_path):
+        script = tmp_path / "run.sh"
+        script.write_text("#!/bin/bash\necho hello")
+        assert _is_elf_binary(script) is False
+
+    def test_empty_file(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.write_bytes(b"")
+        assert _is_elf_binary(empty) is False
+
+    def test_short_file(self, tmp_path):
+        short = tmp_path / "short"
+        short.write_bytes(b"\x7f")
+        assert _is_elf_binary(short) is False
+
+    def test_nonexistent_file(self, tmp_path):
+        assert _is_elf_binary(tmp_path / "nonexistent") is False
+
+
+class TestRunStrings:
+    def _create_binary_with_strings(self, path: Path, embedded_strings: list[str]) -> None:
+        """Create a fake binary with embedded readable strings."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = b"\x7fELF" + b"\x00" * 100
+        for s in embedded_strings:
+            content += s.encode("utf-8") + b"\x00" * 10
+        content += b"\x00" * 100
+        path.write_bytes(content)
+
+    def test_extracts_strings(self, tmp_path):
+        binary = tmp_path / "myapp"
+        self._create_binary_with_strings(binary, [
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+            "some_other_long_string_here",
+        ])
+        result = _run_strings(binary)
+        assert result is not None
+        assert "memory.limit_in_bytes" in result
+
+    def test_empty_file(self, tmp_path):
+        binary = tmp_path / "empty"
+        binary.write_bytes(b"")
+        result = _run_strings(binary)
+        assert result is None
+
+    def test_nonexistent_file(self, tmp_path):
+        result = _run_strings(tmp_path / "nonexistent")
+        assert result is None
+
+
+class TestScanBinaryStrings:
+    def _create_binary_with_strings(self, path: Path, embedded_strings: list[str]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = b"\x7fELF" + b"\x00" * 100
+        for s in embedded_strings:
+            content += s.encode("utf-8") + b"\x00" * 10
+        content += b"\x00" * 100
+        path.write_bytes(content)
+
+    def test_binary_with_v1_patterns(self, tmp_path):
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "myapp",
+            [
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
+            ],
+        )
+        matches, v2_aware = scan_binary_strings(
+            tmp_path, ["/usr/bin/myapp"], debug=False
+        )
+        assert len(matches) > 0
+        assert all(m.confidence == "low" for m in matches)
+        assert all(m.source.startswith("binary:") for m in matches)
+        assert any("memory.limit_in_bytes" in m.pattern for m in matches)
+        assert v2_aware is False
+
+    def test_binary_with_v1_and_v2_patterns(self, tmp_path):
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "myapp",
+            [
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "/sys/fs/cgroup/cgroup.controllers",
+                "memory.max_is_a_long_enough_string",
+            ],
+        )
+        matches, v2_aware = scan_binary_strings(
+            tmp_path, ["/usr/bin/myapp"], debug=False
+        )
+        assert len(matches) > 0
+        assert v2_aware is True
+
+    def test_binary_without_v1_patterns(self, tmp_path):
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "cleanapp",
+            ["just_some_random_long_string_here", "another_normal_string_data"],
+        )
+        matches, v2_aware = scan_binary_strings(
+            tmp_path, ["/usr/bin/cleanapp"], debug=False
+        )
+        assert matches == []
+        assert v2_aware is False
+
+    def test_nonexistent_binary_skipped(self, tmp_path):
+        matches, v2_aware = scan_binary_strings(
+            tmp_path, ["/usr/bin/nonexistent"], debug=False
+        )
+        assert matches == []
+
+    def test_shell_script_skipped(self, tmp_path):
+        script = tmp_path / "usr" / "bin" / "run.sh"
+        script.parent.mkdir(parents=True)
+        script.write_text("#!/bin/bash\ncat /sys/fs/cgroup/memory/memory.limit_in_bytes")
+        matches, v2_aware = scan_binary_strings(
+            tmp_path, ["/usr/bin/run.sh"], debug=False
+        )
+        assert matches == []
+
+    def test_multiple_binaries(self, tmp_path):
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "app1",
+            ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
+        )
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "app2",
+            ["/sys/fs/cgroup/cpu/cpu.cfs_quota_us"],
+        )
+        matches, v2_aware = scan_binary_strings(
+            tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False
+        )
+        assert len(matches) >= 2
+        sources = {m.source for m in matches}
+        assert "binary:/usr/bin/app1" in sources
+        assert "binary:/usr/bin/app2" in sources
+
+    def test_duplicate_binary_refs_deduplicated(self, tmp_path):
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "myapp",
+            ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
+        )
+        matches, _ = scan_binary_strings(
+            tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False
+        )
+        pattern_count = sum(1 for m in matches if m.pattern == "memory.limit_in_bytes")
+        assert pattern_count == 1
+
+    def test_source_prefix_is_binary(self, tmp_path):
+        """Verify the source field uses the binary: prefix."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "local" / "bin" / "cgroup-reader",
+            ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
+        )
+        matches, _ = scan_binary_strings(
+            tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False
+        )
+        assert len(matches) > 0
+        assert matches[0].source == "binary:/usr/local/bin/cgroup-reader"
+
+
+class TestRunDeepScanWithBinary:
+    """Test run_deep_scan integration with binary scanning (step 4)."""
+
+    def _create_binary_with_strings(self, path: Path, embedded_strings: list[str]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = b"\x7fELF" + b"\x00" * 100
+        for s in embedded_strings:
+            content += s.encode("utf-8") + b"\x00" * 10
+        content += b"\x00" * 100
+        path.write_bytes(content)
+
+    def _create_script(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def test_binary_entrypoint_scanned(self, tmp_path):
+        """When entrypoint is a binary, strings scan should find patterns."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "cadvisor",
+            [
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
+                "/sys/fs/cgroup/cpuacct/cpuacct.usage",
+            ],
+        )
+        matches, v2_aware = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="cadvisor:v0.44.0",
+            entrypoint=["/usr/bin/cadvisor"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert all(m.confidence == "low" for m in matches)
+        assert all("binary:" in m.source for m in matches)
+
+    def test_script_entrypoint_not_double_scanned(self, tmp_path):
+        """Shell script entrypoint should only produce high/medium matches, not low."""
+        self._create_script(tmp_path / "entrypoint.sh", """#!/bin/bash
+MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+exec "$@"
+""")
+        matches, _ = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=["/entrypoint.sh"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert all(m.confidence == "high" for m in matches)
+        assert not any("binary:" in m.source for m in matches)
+
+    def test_binary_with_v2_awareness(self, tmp_path):
+        """Binary containing both v1 and v2 patterns should be flagged v2-aware."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "monitor",
+            [
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "/sys/fs/cgroup/cgroup.controllers",
+                "memory.max_and_some_padding",
+            ],
+        )
+        matches, v2_aware = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="monitor:latest",
+            entrypoint=["/usr/bin/monitor"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert v2_aware is True
+
+    def test_mixed_script_and_binary_args(self, tmp_path):
+        """When entrypoint is a script and CMD has a binary, both are scanned."""
+        self._create_script(tmp_path / "wrapper.sh", """#!/bin/bash
+echo "starting"
+exec "$@"
+""")
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "myapp",
+            ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
+        )
+        matches, _ = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=["/wrapper.sh"],
+            cmd=["/usr/bin/myapp"],
+            debug=False,
+        )
+        binary_matches = [m for m in matches if "binary:" in m.source]
+        assert len(binary_matches) > 0
+        assert all(m.confidence == "low" for m in binary_matches)
+
+    def test_no_matches_in_clean_binary(self, tmp_path):
+        """Binary without cgroup refs should produce no matches."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "nginx",
+            ["welcome_to_nginx_server", "http_proxy_module_loaded"],
+        )
+        matches, v2_aware = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="nginx:latest",
+            entrypoint=["/usr/bin/nginx"],
+            debug=False,
         )
         assert matches == []
         assert v2_aware is False


### PR DESCRIPTION
Final step of the deep-scan feature:
- Add _is_elf_binary() to detect ELF binaries by magic bytes
- Add _run_strings() to safely execute `strings` on binaries with size limits (200MB) and timeout (120s)
- Add scan_binary_strings() to scan entrypoint/cmd binaries for cgroup v1 patterns via strings output (confidence: low)
- Wire binary scanning into run_deep_scan() for non-shell-script entrypoints
- Check binary strings output for v2 patterns (v2-awareness)
- Use "binary:<path>" source prefix to distinguish from script matches
- Add comprehensive tests for all new functions

The --deep-scan feature is now fully functional:
- high confidence: cgroup v1 patterns in entrypoint scripts
- medium confidence: patterns in sourced/executed scripts
- low confidence: patterns in binary strings output
- v2-aware detection across all scan levels