### PR TITLE
refactor: move analysis_error to last CSV column

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,12 +719,12 @@ The tool generates a CSV file in the `output` directory (or the path specified b
 | `dotnet_binary` | Path to .NET binary found (or "None") |
 | `dotnet_version` | .NET version detected |
 | `dotnet_cgroup_v2_compatible` | "Yes", "No", "Unknown", or "N/A" |
-| `analysis_error` | Error message if analysis failed |
 | `deep_scan_match` | `"true"` if cgroup v1 patterns found, `"false"` if scanned with no matches, empty if not scanned |
 | `deep_scan_confidence` | Highest confidence level: `"high"`, `"medium"`, or `"low"` (empty if no match) |
 | `deep_scan_sources` | Pipe-separated file paths where matches were found (e.g., `/entrypoint.sh\|/opt/helpers.sh` or `binary:/usr/bin/cadvisor`) |
 | `deep_scan_patterns` | Pipe-separated cgroup v1 patterns matched (e.g., `memory.limit_in_bytes\|cpu.cfs_quota_us`) |
 | `deep_scan_v2_aware` | `"true"` if matched files also contain cgroup v2 patterns, `"false"` if v1-only, empty if no match |
+| `analysis_error` | Error message if analysis failed |
 
 ### Identifying Incompatible Images
 

--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -33,12 +33,12 @@ CSV_COLUMNS = [
     "dotnet_binary",
     "dotnet_version",
     "dotnet_cgroup_v2_compatible",
-    "analysis_error",
     "deep_scan_match",
     "deep_scan_confidence",
     "deep_scan_sources",
     "deep_scan_patterns",
     "deep_scan_v2_aware",
+    "analysis_error",
 ]
 
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -15,7 +15,7 @@ import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-STATE_VERSION = 3
+STATE_VERSION = 4
 
 ANALYSIS_KEYS = (
     "java_binary",
@@ -27,12 +27,12 @@ ANALYSIS_KEYS = (
     "dotnet_binary",
     "dotnet_version",
     "dotnet_cgroup_v2_compatible",
-    "analysis_error",
     "deep_scan_match",
     "deep_scan_confidence",
     "deep_scan_sources",
     "deep_scan_patterns",
     "deep_scan_v2_aware",
+    "analysis_error",
 )
 
 


### PR DESCRIPTION
Move analysis_error from the middle of the CSV to the last position. This field contains variable-length error messages (with commas, quotes, and long URLs) that push all following columns out of alignment when viewed in spreadsheet software or terminal. With analysis_error at the end, all structured columns remain clean and readable.

Bump STATE_VERSION to 4.