### PR TITLE
Add pre-flight check for 'strings' binary when --deep-scan is enabled

### DIFF
--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -488,7 +488,7 @@ def main() -> int:
     # Run system checks (podman, etc.)
     if log_to_file:
         logger.info("Running system checks...")
-    if not run_system_checks(verbose=args.verbose):
+    if not run_system_checks(verbose=args.verbose, deep_scan=args.deep_scan):
         print("\n✗ System checks failed. Please install the required dependencies.")
         if log_to_file:
             logger.error("System checks failed")

--- a/src/system_checks.py
+++ b/src/system_checks.py
@@ -61,12 +61,41 @@ def check_podman_running() -> tuple[bool, str]:
         return False, f"Error testing podman: {e}"
 
 
-def run_system_checks(verbose: bool = False) -> bool:
+def check_strings_installed() -> tuple[bool, str]:
+    """
+    Check if the ``strings`` utility (from binutils) is installed and accessible.
+
+    Returns:
+        Tuple of (success, message with version or error)
+    """
+    try:
+        strings_path = shutil.which("strings")
+        if not strings_path:
+            return False, "strings not found in PATH. Please install binutils."
+
+        result = subprocess.run(
+            ["strings", "--version"],
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            return False, f"strings found but failed to get version: {result.stderr}"
+
+        first_line = (result.stdout or result.stderr).strip().splitlines()[0]
+        return True, f"strings is installed: {first_line}"
+
+    except Exception as e:
+        return False, f"Error checking strings: {e}"
+
+
+def run_system_checks(verbose: bool = False, deep_scan: bool = False) -> bool:
     """
     Run all system checks required for the tool to function.
 
     Args:
         verbose: If True, print detailed output.
+        deep_scan: If True, also verify the ``strings`` utility is available.
 
     Returns:
         True if all checks pass, False otherwise.
@@ -88,5 +117,14 @@ def run_system_checks(verbose: bool = False) -> bool:
     else:
         print(f"✗ {msg}")
         all_passed = False
+
+    # Check strings (only needed for --deep-scan)
+    if deep_scan:
+        strings_installed, msg = check_strings_installed()
+        if strings_installed:
+            print(f"✓ {msg}")
+        else:
+            print(f"✗ {msg}")
+            all_passed = False
 
     return all_passed

--- a/tests/test_system_checks.py
+++ b/tests/test_system_checks.py
@@ -1,0 +1,77 @@
+"""Tests for the system_checks module."""
+
+from unittest.mock import MagicMock, patch
+
+from src.system_checks import (
+    check_strings_installed,
+    run_system_checks,
+)
+
+
+class TestCheckStringsInstalled:
+    """Tests for check_strings_installed()."""
+
+    def test_strings_found(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "GNU strings version 2.40\n"
+        mock_result.stderr = ""
+
+        with patch("src.system_checks.shutil.which", return_value="/usr/bin/strings"), \
+             patch("src.system_checks.subprocess.run", return_value=mock_result):
+            ok, msg = check_strings_installed()
+            assert ok is True
+            assert "strings is installed" in msg
+
+    def test_strings_not_in_path(self):
+        with patch("src.system_checks.shutil.which", return_value=None):
+            ok, msg = check_strings_installed()
+            assert ok is False
+            assert "not found in PATH" in msg
+
+    def test_strings_version_fails(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "some error"
+
+        with patch("src.system_checks.shutil.which", return_value="/usr/bin/strings"), \
+             patch("src.system_checks.subprocess.run", return_value=mock_result):
+            ok, msg = check_strings_installed()
+            assert ok is False
+            assert "failed to get version" in msg
+
+    def test_strings_exception(self):
+        with patch("src.system_checks.shutil.which", side_effect=OSError("boom")):
+            ok, msg = check_strings_installed()
+            assert ok is False
+            assert "Error checking strings" in msg
+
+
+class TestRunSystemChecks:
+    """Tests for run_system_checks() with the deep_scan parameter."""
+
+    def test_deep_scan_false_does_not_check_strings(self):
+        with patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")), \
+             patch("src.system_checks.check_strings_installed") as mock_strings:
+            result = run_system_checks(deep_scan=False)
+            assert result is True
+            mock_strings.assert_not_called()
+
+    def test_deep_scan_true_checks_strings(self):
+        with patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")), \
+             patch("src.system_checks.check_strings_installed", return_value=(True, "strings ok")):
+            result = run_system_checks(deep_scan=True)
+            assert result is True
+
+    def test_deep_scan_true_strings_missing_fails(self):
+        with patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")), \
+             patch("src.system_checks.check_strings_installed", return_value=(False, "not found")):
+            result = run_system_checks(deep_scan=True)
+            assert result is False
+
+    def test_podman_missing_still_fails_with_deep_scan(self):
+        with patch("src.system_checks.check_podman_installed", return_value=(False, "not found")), \
+             patch("src.system_checks.check_strings_installed", return_value=(True, "strings ok")):
+            result = run_system_checks(deep_scan=True)
+            assert result is False

--- a/tests/test_system_checks.py
+++ b/tests/test_system_checks.py
@@ -17,8 +17,10 @@ class TestCheckStringsInstalled:
         mock_result.stdout = "GNU strings version 2.40\n"
         mock_result.stderr = ""
 
-        with patch("src.system_checks.shutil.which", return_value="/usr/bin/strings"), \
-             patch("src.system_checks.subprocess.run", return_value=mock_result):
+        with (
+            patch("src.system_checks.shutil.which", return_value="/usr/bin/strings"),
+            patch("src.system_checks.subprocess.run", return_value=mock_result),
+        ):
             ok, msg = check_strings_installed()
             assert ok is True
             assert "strings is installed" in msg
@@ -35,8 +37,10 @@ class TestCheckStringsInstalled:
         mock_result.stdout = ""
         mock_result.stderr = "some error"
 
-        with patch("src.system_checks.shutil.which", return_value="/usr/bin/strings"), \
-             patch("src.system_checks.subprocess.run", return_value=mock_result):
+        with (
+            patch("src.system_checks.shutil.which", return_value="/usr/bin/strings"),
+            patch("src.system_checks.subprocess.run", return_value=mock_result),
+        ):
             ok, msg = check_strings_installed()
             assert ok is False
             assert "failed to get version" in msg
@@ -52,26 +56,34 @@ class TestRunSystemChecks:
     """Tests for run_system_checks() with the deep_scan parameter."""
 
     def test_deep_scan_false_does_not_check_strings(self):
-        with patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")), \
-             patch("src.system_checks.check_strings_installed") as mock_strings:
+        with (
+            patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")),
+            patch("src.system_checks.check_strings_installed") as mock_strings,
+        ):
             result = run_system_checks(deep_scan=False)
             assert result is True
             mock_strings.assert_not_called()
 
     def test_deep_scan_true_checks_strings(self):
-        with patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")), \
-             patch("src.system_checks.check_strings_installed", return_value=(True, "strings ok")):
+        with (
+            patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")),
+            patch("src.system_checks.check_strings_installed", return_value=(True, "strings ok")),
+        ):
             result = run_system_checks(deep_scan=True)
             assert result is True
 
     def test_deep_scan_true_strings_missing_fails(self):
-        with patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")), \
-             patch("src.system_checks.check_strings_installed", return_value=(False, "not found")):
+        with (
+            patch("src.system_checks.check_podman_installed", return_value=(True, "podman ok")),
+            patch("src.system_checks.check_strings_installed", return_value=(False, "not found")),
+        ):
             result = run_system_checks(deep_scan=True)
             assert result is False
 
     def test_podman_missing_still_fails_with_deep_scan(self):
-        with patch("src.system_checks.check_podman_installed", return_value=(False, "not found")), \
-             patch("src.system_checks.check_strings_installed", return_value=(True, "strings ok")):
+        with (
+            patch("src.system_checks.check_podman_installed", return_value=(False, "not found")),
+            patch("src.system_checks.check_strings_installed", return_value=(True, "strings ok")),
+        ):
             result = run_system_checks(deep_scan=True)
             assert result is False


### PR DESCRIPTION
Prevents discovering a missing 'strings' utility mid-scan by verifying its availability at startup, alongside the existing podman check.