### PR TITLE
feat: detect Go cgroup library imports in binary deep-scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ When the deep-scan finds cgroup v1 patterns in a file that **also** contains cgr
 | `false` | (empty) | No cgroup v1 references found — image is fine |
 | `true` | `true` | v1 references found but image handles both v1 and v2 — likely safe |
 | `true` | `false` | v1 references found with no v2 fallback — **investigate and remediate** |
+| `false` | (empty) | (has go_cgroup_libs) | No direct v1 patterns but binary uses cgroup libraries — investigate |
 
 #### Source Chain Following
 
@@ -638,6 +639,19 @@ source "${SCRIPT_DIR}/cgroup-helpers.sh"
 Shell variable paths like `${SCRIPT_DIR}/file.sh` are resolved by extracting the filename and looking for it relative to the sourcing script's directory.
 
 Limits: maximum source-chain depth of 5, maximum script size of 1 MB, symlinks that escape the rootfs are blocked.
+
+#### Go Cgroup Library Detection
+
+Go binaries compiled with static linking embed the full import paths of all dependencies. The deep-scan checks for known Go packages that interact with cgroups:
+
+- `github.com/opencontainers/runc/libcontainer/cgroups` — low-level cgroup management
+- `github.com/containerd/cgroups` — containerd cgroup library
+- `github.com/prometheus/procfs` — Prometheus metrics from procfs/cgroupfs
+- `github.com/google/cadvisor/container` — cAdvisor container stats
+- `go.uber.org/automaxprocs` — auto-tuning GOMAXPROCS from cgroup CPU limits
+- `github.com/KimMachineGun/automemlimit` — auto-tuning memory limits from cgroups
+
+These are reported in the `deep_scan_go_cgroup_libs` CSV column as an informational signal. Finding a library does **not** set `deep_scan_match=true` — the library might be used in v2-compatible mode. The column helps operators identify binaries that likely interact with cgroups even when no direct v1 path patterns were found.
 
 #### Deep Scan Example
 
@@ -724,6 +738,7 @@ The tool generates a CSV file in the `output` directory (or the path specified b
 | `deep_scan_sources` | Pipe-separated file paths where matches were found (e.g., `/entrypoint.sh\|/opt/helpers.sh` or `binary:/usr/bin/cadvisor`) |
 | `deep_scan_patterns` | Pipe-separated cgroup v1 patterns matched (e.g., `memory.limit_in_bytes\|cpu.cfs_quota_us`) |
 | `deep_scan_v2_aware` | `"true"` if matched files also contain cgroup v2 patterns, `"false"` if v1-only, empty if no match |
+| `deep_scan_go_cgroup_libs` | Pipe-separated Go package paths that interact with cgroups (e.g., `github.com/prometheus/procfs\|github.com/containerd/cgroups`). Informational — these libraries may use v1 or v2 |
 | `analysis_error` | Error message if analysis failed |
 
 ### Identifying Incompatible Images

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ When the deep-scan finds cgroup v1 patterns in a file that **also** contains cgr
 | `false` | (empty) | No cgroup v1 references found — image is fine |
 | `true` | `true` | v1 references found but image handles both v1 and v2 — likely safe |
 | `true` | `false` | v1 references found with no v2 fallback — **investigate and remediate** |
-| `false` | (empty) | (has go_cgroup_libs) | No direct v1 patterns but binary uses cgroup libraries — investigate |
+| `false` | (empty) | No direct v1 patterns but binary uses Go cgroup libraries — investigate |
 
 #### Source Chain Following
 

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -442,6 +442,11 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
         v1_only = deep_scan_found - v2_aware_count
         if v1_only > 0:
             print(f"        ✗ v1-only (likely incompatible): {v1_only}")
+        go_libs_count = sum(
+            1 for img in images if img.get("deep_scan_go_cgroup_libs", "") != ""
+        )
+        if go_libs_count:
+            print(f"        📦 Go cgroup libraries detected: {go_libs_count} images")
     skipped_count = len(skipped_images) if skipped_images else 0
     print(f"      Images skipped (timeout): {skipped_count}")
 

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -301,3 +301,4 @@ class AnalysisOrchestrator:
                 record["deep_scan_sources"] = result.deep_scan_sources
                 record["deep_scan_patterns"] = result.deep_scan_patterns
                 record["deep_scan_v2_aware"] = result.deep_scan_v2_aware
+                record["deep_scan_go_cgroup_libs"] = result.deep_scan_go_cgroup_libs

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -162,6 +162,58 @@ def find_cgroupv2_patterns(text: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Known Go packages that interact with cgroups.
+# If these import paths appear in the `strings` output of a static Go binary,
+# the binary likely reads or manipulates cgroup files at runtime.
+# ---------------------------------------------------------------------------
+GO_CGROUP_PACKAGES = (
+    # Low-level cgroup libraries
+    "github.com/opencontainers/runc/libcontainer/cgroups",
+    "github.com/containerd/cgroups",
+    "github.com/opencontainers/cgroups",
+    # Metrics/monitoring libraries that read cgroup stats
+    "github.com/prometheus/procfs",
+    "github.com/google/cadvisor/container",
+    "github.com/google/cadvisor/cgroup",
+    # Go runtime cgroup awareness (embedded in all recent Go binaries,
+    # but these specific sub-paths indicate direct cgroup interaction)
+    "runtime/cgroup",
+    # Container runtime libraries
+    "github.com/docker/docker/daemon/stats",
+    "github.com/containers/podman",
+    # Kubernetes cgroup management
+    "k8s.io/kubernetes/pkg/kubelet/cm",
+    "k8s.io/kubernetes/pkg/kubelet/stats",
+    # Auto-tuning libraries that read cgroups for GOMAXPROCS/memory
+    "go.uber.org/automaxprocs",
+    "github.com/KimMachineGun/automemlimit",
+)
+
+# Build a regex for efficient matching of Go package paths.
+# These are always preceded by a path separator or start of line in strings output.
+_GO_PKG_STRINGS = list(GO_CGROUP_PACKAGES)
+_GO_PKG_STRINGS.sort(key=len, reverse=True)
+GO_CGROUP_REGEX = re.compile("|".join(re.escape(p) for p in _GO_PKG_STRINGS))
+
+
+def find_go_cgroup_deps(text: str) -> list[str]:
+    """Return de-duplicated Go cgroup package paths found in *text*.
+
+    Args:
+        text: Output from `strings` command on a Go binary.
+
+    Returns:
+        List of unique matched Go package paths, in order of first occurrence.
+    """
+    seen: dict[str, None] = {}
+    for match in GO_CGROUP_REGEX.finditer(text):
+        pkg = match.group(0)
+        if pkg not in seen:
+            seen[pkg] = None
+    return list(seen)
+
+
+# ---------------------------------------------------------------------------
 # Patterns for detecting sourced/executed scripts in shell scripts
 # ---------------------------------------------------------------------------
 _SOURCE_PATTERN = re.compile(
@@ -347,15 +399,16 @@ def scan_binary_strings(
     extract_path: Path,
     binary_refs: list[str],
     debug: bool = False,
-) -> tuple[list, bool]:
+) -> tuple[list, bool, list[str]]:
     """Scan binary files via `strings` for cgroup v1 references.
 
     For each binary reference:
     1. Resolve it in the extracted rootfs
     2. Verify it's an ELF binary
     3. Run `strings` on it
-    4. Check the output for cgroup v1 patterns
-    5. Check for cgroup v2 patterns (v2-awareness)
+    4. Check the output for Go cgroup library imports
+    5. Check the output for cgroup v1 patterns
+    6. Check for cgroup v2 patterns (v2-awareness)
 
     Args:
         extract_path: Path to the extracted container rootfs.
@@ -363,15 +416,17 @@ def scan_binary_strings(
         debug: Enable debug output.
 
     Returns:
-        Tuple of (matches, v2_aware):
+        Tuple of (matches, v2_aware, go_cgroup_libs):
         - matches: list of DeepScanMatch objects with confidence="low"
         - v2_aware: True if any binary contains both v1 and v2 patterns
+        - go_cgroup_libs: list of detected Go cgroup package paths
     """
     from .image_analyzer import DeepScanMatch
 
     matches: list[DeepScanMatch] = []
     v2_aware = False
     scanned_binaries: set[str] = set()
+    all_go_deps: list[str] = []
 
     for binary_ref in binary_refs:
         resolved = _resolve_script_in_rootfs(binary_ref, extract_path)
@@ -401,6 +456,13 @@ def scan_binary_strings(
         if strings_output is None:
             continue
 
+        # Check for Go cgroup library imports
+        go_deps = find_go_cgroup_deps(strings_output)
+        if go_deps:
+            all_go_deps.extend(dep for dep in go_deps if dep not in all_go_deps)
+            if debug:
+                print(f"      [DEBUG]   Found {len(go_deps)} Go cgroup libraries: {', '.join(go_deps)}")
+
         v1_patterns = find_cgroupv1_patterns(strings_output)
         if v1_patterns:
             source = f"binary:{binary_ref}"
@@ -423,7 +485,7 @@ def scan_binary_strings(
         elif debug:
             print(f"      [DEBUG]   No cgroup v1 patterns found in {binary_ref}")
 
-    return matches, v2_aware
+    return matches, v2_aware, all_go_deps
 
 
 def _extract_sourced_paths(content: str) -> list[str]:
@@ -594,7 +656,7 @@ def run_deep_scan(
     entrypoint: list[str] | None = None,
     cmd: list[str] | None = None,
     debug: bool = False,
-) -> tuple[list, bool]:
+) -> tuple[list, bool, list[str]]:
     """Run all deep-scan heuristics on an extracted container rootfs.
 
     Args:
@@ -605,9 +667,10 @@ def run_deep_scan(
         debug: Enable debug output.
 
     Returns:
-        Tuple of (matches, v2_aware):
+        Tuple of (matches, v2_aware, go_cgroup_libs):
         - matches: list of DeepScanMatch objects
         - v2_aware: True if any scanned source has both v1 and v2 patterns
+        - go_cgroup_libs: list of detected Go cgroup package paths
     """
     if debug:
         print(f"      [DEBUG] Deep scan enabled for {image_name}")
@@ -618,6 +681,7 @@ def run_deep_scan(
 
     all_matches: list = []
     v2_aware = False
+    all_go_libs: list[str] = []
 
     combined: list[str] = []
     if entrypoint:
@@ -661,7 +725,7 @@ def run_deep_scan(
     if binary_refs:
         if debug:
             print(f"      [DEBUG] Binary refs to scan with strings: {binary_refs}")
-        binary_matches, binary_v2_aware = scan_binary_strings(
+        binary_matches, binary_v2_aware, go_libs = scan_binary_strings(
             extract_path=extract_path,
             binary_refs=binary_refs,
             debug=debug,
@@ -669,5 +733,6 @@ def run_deep_scan(
         all_matches.extend(binary_matches)
         if binary_v2_aware:
             v2_aware = True
+        all_go_libs.extend(lib for lib in go_libs if lib not in all_go_libs)
 
-    return all_matches, v2_aware
+    return all_matches, v2_aware, all_go_libs

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -50,6 +50,7 @@ class ImageAnalysisResult:
     dotnet_binaries: list[BinaryInfo] = field(default_factory=list)
     deep_scan_matches: list[DeepScanMatch] = field(default_factory=list)
     deep_scan_v2_aware_flag: bool = False
+    deep_scan_go_cgroup_libs_list: list[str] = field(default_factory=list)
     error: str | None = None
 
     @property
@@ -171,6 +172,16 @@ class ImageAnalysisResult:
         if not self.deep_scan_matches:
             return ""
         return "true" if self.deep_scan_v2_aware_flag else "false"
+
+    @property
+    def deep_scan_go_cgroup_libs(self) -> str:
+        """Return pipe-separated Go cgroup library paths detected in binaries.
+
+        Empty string if no deep scan was performed or no libraries detected.
+        """
+        if not self.deep_scan_go_cgroup_libs_list:
+            return ""
+        return "|".join(self.deep_scan_go_cgroup_libs_list)
 
 
 class ImageAnalyzer:
@@ -1241,7 +1252,7 @@ class ImageAnalyzer:
                 entrypoint, cmd = self._get_image_entrypoint(podman_image, debug=debug)
                 from .deep_scan import run_deep_scan
 
-                deep_matches, v2_aware = run_deep_scan(
+                deep_matches, v2_aware, go_libs = run_deep_scan(
                     extract_path=extract_path,
                     image_name=podman_image,
                     entrypoint=entrypoint,
@@ -1250,6 +1261,7 @@ class ImageAnalyzer:
                 )
                 result.deep_scan_matches = deep_matches
                 result.deep_scan_v2_aware_flag = v2_aware
+                result.deep_scan_go_cgroup_libs_list = go_libs
 
             # Report findings
             if result.java_binaries:
@@ -1275,8 +1287,12 @@ class ImageAnalyzer:
                     src_matches = [m for m in result.deep_scan_matches if m.source == src]
                     patterns_str = ", ".join(dict.fromkeys(m.pattern for m in src_matches))
                     print(f"        [{src_matches[0].confidence}] {src}: {patterns_str}")
+                if result.deep_scan_go_cgroup_libs_list:
+                    print(f"      📦 Go cgroup libraries: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
             elif self.deep_scan:
                 print("      ✓ Deep-scan: no cgroup v1 references found")
+                if result.deep_scan_go_cgroup_libs_list:
+                    print(f"      📦 Go cgroup libraries detected: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
 
             if not result.java_binaries and not result.node_binaries and not result.dotnet_binaries:
                 print("      No Java, Node.js, or .NET binaries found")

--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -38,6 +38,7 @@ CSV_COLUMNS = [
     "deep_scan_sources",
     "deep_scan_patterns",
     "deep_scan_v2_aware",
+    "deep_scan_go_cgroup_libs",
     "analysis_error",
 ]
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -15,7 +15,7 @@ import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-STATE_VERSION = 4
+STATE_VERSION = 5
 
 ANALYSIS_KEYS = (
     "java_binary",
@@ -32,6 +32,7 @@ ANALYSIS_KEYS = (
     "deep_scan_sources",
     "deep_scan_patterns",
     "deep_scan_v2_aware",
+    "deep_scan_go_cgroup_libs",
     "analysis_error",
 )
 

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -670,6 +670,7 @@ class TestApplyResultsDeepScan:
         assert images[0]["deep_scan_sources"] == "/entry.sh"
         assert images[0]["deep_scan_patterns"] == "memory.limit_in_bytes"
         assert images[0]["deep_scan_v2_aware"] == "false"
+        assert images[0]["deep_scan_go_cgroup_libs"] == ""
 
     def test_deep_scan_fields_empty_when_no_matches(self):
         images = [{"image_name": "test:latest"}]
@@ -681,3 +682,15 @@ class TestApplyResultsDeepScan:
         assert images[0]["deep_scan_sources"] == ""
         assert images[0]["deep_scan_patterns"] == ""
         assert images[0]["deep_scan_v2_aware"] == ""
+        assert images[0]["deep_scan_go_cgroup_libs"] == ""
+
+    def test_deep_scan_go_libs_mapped(self):
+        images = [{"image_name": "test:latest"}]
+        result = ImageAnalysisResult(
+            image_name="test:latest",
+            image_id="abc",
+            deep_scan_go_cgroup_libs_list=["github.com/prometheus/procfs"],
+        )
+        cache = {"test:latest": result}
+        AnalysisOrchestrator._apply_results(images, cache)
+        assert images[0]["deep_scan_go_cgroup_libs"] == "github.com/prometheus/procfs"

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -10,6 +10,7 @@ from src.deep_scan import (
     CGROUPV1_REGEX,
     CGROUPV2_FILE_NAMES,
     CGROUPV2_REGEX,
+    GO_CGROUP_PACKAGES,
     _extract_sourced_paths,
     _is_elf_binary,
     _is_shell_script,
@@ -17,6 +18,7 @@ from src.deep_scan import (
     _run_strings,
     find_cgroupv1_patterns,
     find_cgroupv2_patterns,
+    find_go_cgroup_deps,
     run_deep_scan,
     scan_binary_strings,
     scan_entrypoint_scripts,
@@ -661,7 +663,7 @@ MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 exec "$@"
 """,
         )
-        matches, v2_aware = run_deep_scan(
+        matches, v2_aware, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -672,7 +674,7 @@ exec "$@"
         assert v2_aware is False
 
     def test_without_entrypoint(self, tmp_path):
-        matches, v2_aware = run_deep_scan(
+        matches, v2_aware, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=None,
@@ -693,7 +695,7 @@ else
 fi
 """,
         )
-        matches, v2_aware = run_deep_scan(
+        matches, v2_aware, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -704,7 +706,7 @@ fi
 
     def test_debug_does_not_crash(self, tmp_path):
         """Debug mode should not raise exceptions."""
-        matches, v2_aware = run_deep_scan(
+        matches, v2_aware, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             debug=True,
@@ -789,7 +791,7 @@ class TestScanBinaryStrings:
                 "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
             ],
         )
-        matches, v2_aware = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert len(matches) > 0
         assert all(m.confidence == "low" for m in matches)
         assert all(m.source.startswith("binary:") for m in matches)
@@ -805,7 +807,7 @@ class TestScanBinaryStrings:
                 "memory.max_is_a_long_enough_string",
             ],
         )
-        matches, v2_aware = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert len(matches) > 0
         assert v2_aware is True
 
@@ -814,19 +816,19 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "cleanapp",
             ["just_some_random_long_string_here", "another_normal_string_data"],
         )
-        matches, v2_aware = scan_binary_strings(tmp_path, ["/usr/bin/cleanapp"], debug=False)
+        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/cleanapp"], debug=False)
         assert matches == []
         assert v2_aware is False
 
     def test_nonexistent_binary_skipped(self, tmp_path):
-        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/nonexistent"], debug=False)
+        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/nonexistent"], debug=False)
         assert matches == []
 
     def test_shell_script_skipped(self, tmp_path):
         script = tmp_path / "usr" / "bin" / "run.sh"
         script.parent.mkdir(parents=True)
         script.write_text("#!/bin/bash\ncat /sys/fs/cgroup/memory/memory.limit_in_bytes")
-        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/run.sh"], debug=False)
+        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/run.sh"], debug=False)
         assert matches == []
 
     def test_multiple_binaries(self, tmp_path):
@@ -838,7 +840,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "app2",
             ["/sys/fs/cgroup/cpu/cpu.cfs_quota_us"],
         )
-        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
+        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
         assert len(matches) >= 2
         sources = {m.source for m in matches}
         assert "binary:/usr/bin/app1" in sources
@@ -849,7 +851,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False)
+        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False)
         pattern_count = sum(1 for m in matches if m.pattern == "memory.limit_in_bytes")
         assert pattern_count == 1
 
@@ -859,7 +861,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "local" / "bin" / "cgroup-reader",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _ = scan_binary_strings(tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False)
+        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False)
         assert len(matches) > 0
         assert matches[0].source == "binary:/usr/local/bin/cgroup-reader"
 
@@ -890,7 +892,7 @@ class TestRunDeepScanWithBinary:
                 "/sys/fs/cgroup/cpuacct/cpuacct.usage",
             ],
         )
-        matches, _ = run_deep_scan(
+        matches, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="cadvisor:v0.44.0",
             entrypoint=["/usr/bin/cadvisor"],
@@ -909,7 +911,7 @@ MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 exec "$@"
 """,
         )
-        matches, _ = run_deep_scan(
+        matches, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -929,7 +931,7 @@ exec "$@"
                 "memory.max_and_some_padding",
             ],
         )
-        matches, v2_aware = run_deep_scan(
+        matches, v2_aware, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="monitor:latest",
             entrypoint=["/usr/bin/monitor"],
@@ -951,7 +953,7 @@ exec "$@"
             tmp_path / "usr" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _ = run_deep_scan(
+        matches, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/wrapper.sh"],
@@ -968,7 +970,7 @@ exec "$@"
             tmp_path / "usr" / "bin" / "nginx",
             ["welcome_to_nginx_server", "http_proxy_module_loaded"],
         )
-        matches, v2_aware = run_deep_scan(
+        matches, v2_aware, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="nginx:latest",
             entrypoint=["/usr/bin/nginx"],
@@ -993,7 +995,7 @@ exec /usr/local/bin/myapp
                 "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
             ],
         )
-        matches, _ = run_deep_scan(
+        matches, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1016,7 +1018,7 @@ exec /usr/local/bin/myapp
             tmp_path / "usr" / "local" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _ = run_deep_scan(
+        matches, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1048,7 +1050,7 @@ echo hello
 exec "$@"
 """,
         )
-        matches, _ = run_deep_scan(
+        matches, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1056,3 +1058,150 @@ exec "$@"
             debug=False,
         )
         assert not any("binary:/bin/bash" in m.source for m in matches)
+
+
+class TestGoCgroupPackages:
+    """Verify Go package constants are well-formed."""
+
+    def test_no_duplicates(self):
+        assert len(GO_CGROUP_PACKAGES) == len(set(GO_CGROUP_PACKAGES))
+
+    def test_all_contain_slash_or_runtime(self):
+        for pkg in GO_CGROUP_PACKAGES:
+            assert "/" in pkg or pkg.startswith("runtime/"), f"{pkg} should contain / or start with runtime/"
+
+
+class TestFindGoCgroupDeps:
+    """Tests for find_go_cgroup_deps()."""
+
+    def test_empty_string(self):
+        assert find_go_cgroup_deps("") == []
+
+    def test_finds_procfs(self):
+        text = """
+runtime.goexit
+github.com/prometheus/procfs
+net/http
+"""
+        result = find_go_cgroup_deps(text)
+        assert "github.com/prometheus/procfs" in result
+
+    def test_finds_multiple_packages(self):
+        text = """
+github.com/opencontainers/runc/libcontainer/cgroups
+github.com/prometheus/procfs
+go.uber.org/automaxprocs
+"""
+        result = find_go_cgroup_deps(text)
+        assert len(result) == 3
+
+    def test_no_match_on_unrelated_packages(self):
+        text = """
+github.com/gorilla/mux
+golang.org/x/net
+encoding/json
+"""
+        assert find_go_cgroup_deps(text) == []
+
+    def test_deduplicated(self):
+        text = """
+github.com/prometheus/procfs
+github.com/prometheus/procfs/internal
+github.com/prometheus/procfs
+"""
+        result = find_go_cgroup_deps(text)
+        assert result.count("github.com/prometheus/procfs") == 1
+
+    def test_cadvisor_packages(self):
+        text = """
+github.com/google/cadvisor/container
+github.com/google/cadvisor/cgroup
+"""
+        result = find_go_cgroup_deps(text)
+        assert "github.com/google/cadvisor/container" in result
+        assert "github.com/google/cadvisor/cgroup" in result
+
+    def test_containerd_cgroups(self):
+        text = "github.com/containerd/cgroups"
+        result = find_go_cgroup_deps(text)
+        assert "github.com/containerd/cgroups" in result
+
+    def test_automaxprocs(self):
+        text = "go.uber.org/automaxprocs"
+        result = find_go_cgroup_deps(text)
+        assert "go.uber.org/automaxprocs" in result
+
+
+class TestScanBinaryStringsGoDeps:
+    """Tests for Go dep detection in scan_binary_strings."""
+
+    def _create_binary_with_strings(self, path: Path, embedded_strings: list[str]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = b"\x7fELF" + b"\x00" * 100
+        for s in embedded_strings:
+            content += s.encode("utf-8") + b"\x00" * 10
+        content += b"\x00" * 100
+        path.write_bytes(content)
+
+    def test_go_deps_returned(self, tmp_path):
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "exporter",
+            [
+                "github.com/prometheus/procfs",
+                "net/http.ListenAndServe",
+            ],
+        )
+        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
+        assert "github.com/prometheus/procfs" in go_libs
+
+    def test_go_deps_without_v1_patterns(self, tmp_path):
+        """Binary with Go cgroup libs but no direct v1 patterns."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "exporter",
+            [
+                "github.com/prometheus/procfs",
+                "just_some_normal_long_text_here",
+            ],
+        )
+        matches, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
+        assert matches == []
+        assert "github.com/prometheus/procfs" in go_libs
+
+    def test_go_deps_with_v1_patterns(self, tmp_path):
+        """Binary with both Go cgroup libs AND v1 patterns."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "cadvisor",
+            [
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "github.com/google/cadvisor/container",
+                "github.com/opencontainers/runc/libcontainer/cgroups",
+            ],
+        )
+        matches, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/cadvisor"], debug=False)
+        assert len(matches) > 0
+        assert len(go_libs) >= 2
+
+    def test_no_go_deps_in_non_go_binary(self, tmp_path):
+        """C binary without Go packages."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "myapp",
+            [
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "libc.so.6_is_a_long_string",
+            ],
+        )
+        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        assert go_libs == []
+
+    def test_go_deps_deduplicated_across_binaries(self, tmp_path):
+        """Same Go package in two binaries should appear once."""
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "app1",
+            ["github.com/prometheus/procfs"],
+        )
+        self._create_binary_with_strings(
+            tmp_path / "usr" / "bin" / "app2",
+            ["github.com/prometheus/procfs"],
+        )
+        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
+        assert go_libs.count("github.com/prometheus/procfs") == 1

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -789,3 +789,18 @@ class TestDeepScanResult:
     def test_v2_aware_empty_when_no_matches(self):
         result = ImageAnalysisResult("t", "")
         assert result.deep_scan_v2_aware == ""
+
+    def test_go_cgroup_libs_property(self):
+        result = ImageAnalysisResult(
+            "t",
+            "",
+            deep_scan_go_cgroup_libs_list=[
+                "github.com/prometheus/procfs",
+                "github.com/containerd/cgroups",
+            ],
+        )
+        assert result.deep_scan_go_cgroup_libs == "github.com/prometheus/procfs|github.com/containerd/cgroups"
+
+    def test_go_cgroup_libs_empty(self):
+        result = ImageAnalysisResult("t", "")
+        assert result.deep_scan_go_cgroup_libs == ""


### PR DESCRIPTION
Add Go cgroup library detection to the deep-scan binary analysis. When `strings` is run on an ELF binary, also check for known Go package import paths that interact with cgroups (e.g., github.com/prometheus/procfs, github.com/containerd/cgroups, go.uber.org/automaxprocs).

Results are reported in a new `deep_scan_go_cgroup_libs` CSV column as an informational signal. Finding a library does NOT set deep_scan_match=true — the library might be used in v2-compatible mode. This helps operators identify binaries that interact with cgroups even when no direct v1 path patterns were found (e.g., Prometheus node-exporter).

- Add GO_CGROUP_PACKAGES catalog with 13 known packages
- Add find_go_cgroup_deps() function
- Integrate detection into scan_binary_strings()
- Add deep_scan_go_cgroup_libs CSV column and property
- Bump STATE_VERSION to 5