### PR TITLE
feat: propagate verbose debug logging to log file

### DIFF
--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -38,6 +38,8 @@ from src.rootfs_manager import RootFSManager
 from src.scan_state import ScanState
 from src.system_checks import run_system_checks
 
+logger = logging.getLogger("image-cgroupsv2-inspector")
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command line arguments."""
@@ -320,9 +322,10 @@ def setup_logging(log_to_file: bool, log_file: str, verbose: bool) -> logging.Lo
     """
     Set up logging configuration.
 
-    The file handler always logs at DEBUG level so the log file captures
-    the same detail as ``-v`` stdout output.  The ``-v`` flag only controls
-    whether a StreamHandler is attached for console output.
+    The file handler is attached to the **root** logger so that every
+    module using ``logging.getLogger(__name__)`` automatically inherits
+    it via propagation.  The file handler always logs at DEBUG level so
+    the log file captures the same detail as ``-v`` stdout output.
 
     Args:
         log_to_file: Whether to enable file logging.
@@ -330,24 +333,27 @@ def setup_logging(log_to_file: bool, log_file: str, verbose: bool) -> logging.Lo
         verbose: Whether to enable verbose (DEBUG) logging to stdout.
 
     Returns:
-        Configured logger instance.
+        Configured logger instance for the CLI script.
     """
-    logger = logging.getLogger("image-cgroupsv2-inspector")
-    logger.setLevel(logging.DEBUG)
-
-    file_format = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
 
     if log_to_file:
+        file_format = logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(name)s.%(funcName)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
         file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(file_format)
-        logger.addHandler(file_handler)
+        root_logger.addHandler(file_handler)
         print(f"📝 Logging to file: {log_file}")
 
-    return logger
+    # Silence noisy third-party loggers that would flood the log file
+    for name in ("urllib3", "kubernetes", "requests", "chardet", "charset_normalizer"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+    return logging.getLogger("image-cgroupsv2-inspector")
 
 
 def print_banner():
@@ -362,40 +368,36 @@ def print_banner():
     print(banner)
 
 
-def setup_rootfs(rootfs_path: str, logger: logging.Logger | None = None, skip_disk_check: bool = False) -> bool:
+def setup_rootfs(rootfs_path: str, skip_disk_check: bool = False) -> bool:
     """
     Set up the rootfs directory with proper permissions and ACLs.
 
     Args:
         rootfs_path: Path where rootfs directory will be created.
-        logger: Logger instance for file logging.
         skip_disk_check: If True, insufficient disk space produces a
             warning instead of a fatal error.
 
     Returns:
         True if successful, False otherwise.
     """
-    _log = logger or logging.getLogger("image-cgroupsv2-inspector")
     print(f"\n🔧 Setting up rootfs directory at: {rootfs_path}")
-    _log.info("Setting up rootfs directory at: %s", rootfs_path)
+    logger.info("Setting up rootfs directory at: %s", rootfs_path)
 
     manager = RootFSManager(rootfs_path)
 
     success, msg = manager.create_rootfs_directory(skip_disk_check=skip_disk_check)
     if not success:
         print(f"✗ Failed to create rootfs: {msg}")
-        _log.error("Failed to create rootfs: %s", msg)
+        logger.error("Failed to create rootfs: %s", msg)
         return False
 
     print(f"\n✓ {msg}")
-    _log.info("Rootfs setup successful: %s", msg)
+    logger.info("Rootfs setup successful: %s", msg)
     return True
 
 
 def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None = None) -> None:
     """Print analysis summary from image record dicts."""
-    _log = logging.getLogger("image-cgroupsv2-inspector")
-
     java_found = sum(1 for img in images if img.get("java_binary", "None") != "None")
     node_found = sum(1 for img in images if img.get("node_binary", "None") != "None")
     dotnet_found = sum(1 for img in images if img.get("dotnet_binary", "None") != "None")
@@ -409,7 +411,7 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
     dotnet_incompat = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "No")
     dotnet_unknown = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "Unknown")
 
-    _log.debug("Analysis Results: Java found=%d (compat=%d, incompat=%d, unknown=%d), "
+    logger.debug("Analysis Results: Java found=%d (compat=%d, incompat=%d, unknown=%d), "
                "Node.js found=%d (compat=%d, incompat=%d, unknown=%d), "
                ".NET found=%d (compat=%d, incompat=%d, unknown=%d)",
                java_found, java_compat, java_incompat, java_unknown,
@@ -438,7 +440,7 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
     deep_scan_found = sum(1 for img in images if img.get("deep_scan_match") == "true")
     if deep_scan_found > 0 or any(img.get("deep_scan_match") != "" for img in images):
         print(f"      Deep-scan matches: {deep_scan_found} images with cgroup v1 references")
-        _log.debug("Deep-scan matches: %d images with cgroup v1 references", deep_scan_found)
+        logger.debug("Deep-scan matches: %d images with cgroup v1 references", deep_scan_found)
         high = sum(1 for img in images if img.get("deep_scan_confidence") == "high")
         medium = sum(1 for img in images if img.get("deep_scan_confidence") == "medium")
         low = sum(1 for img in images if img.get("deep_scan_confidence") == "low")
@@ -448,22 +450,22 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
             print(f"        ⚠ medium confidence: {medium}")
         if low:
             print(f"        ⚠ low confidence: {low}")
-        _log.debug("Deep-scan confidence breakdown: high=%d, medium=%d, low=%d", high, medium, low)
+        logger.debug("Deep-scan confidence breakdown: high=%d, medium=%d, low=%d", high, medium, low)
         v2_aware_count = sum(1 for img in images if img.get("deep_scan_v2_aware") == "true")
         if v2_aware_count:
             print(f"        ✓ v2-aware (dual v1+v2 support): {v2_aware_count}")
         v1_only = deep_scan_found - v2_aware_count
         if v1_only > 0:
             print(f"        ✗ v1-only (likely incompatible): {v1_only}")
-        _log.debug("Deep-scan: v2-aware=%d, v1-only=%d", v2_aware_count, v1_only)
+        logger.debug("Deep-scan: v2-aware=%d, v1-only=%d", v2_aware_count, v1_only)
         go_libs_count = sum(
             1 for img in images if img.get("deep_scan_go_cgroup_libs", "") != ""
         )
         if go_libs_count:
-            _log.debug("Go cgroup libraries detected in %d images", go_libs_count)
+            logger.debug("Go cgroup libraries detected in %d images", go_libs_count)
             print(f"        📦 Go cgroup libraries detected: {go_libs_count} images")
     skipped_count = len(skipped_images) if skipped_images else 0
-    _log.debug("Images skipped (timeout): %d", skipped_count)
+    logger.debug("Images skipped (timeout): %d", skipped_count)
     print(f"      Images skipped (timeout): {skipped_count}")
 
 
@@ -496,10 +498,9 @@ def main() -> int:
     # Resolve state directory early (default = output dir)
     state_dir = args.state_dir if args.state_dir else args.output_dir
 
-    # Set up logging
     # If --log-file is specified with a non-default value, imply --log-to-file
     log_to_file = args.log_to_file or args.log_file != "image-cgroupsv2-inspector.log"
-    logger = setup_logging(log_to_file, args.log_file, args.verbose)
+    setup_logging(log_to_file, args.log_file, args.verbose)
 
     logger.info("=" * 60)
     logger.info("image-cgroupsv2-inspector started")
@@ -521,7 +522,7 @@ def main() -> int:
 
     # Handle rootfs path if provided
     if args.rootfs_path:
-        if not setup_rootfs(args.rootfs_path, logger, skip_disk_check=args.skip_disk_check):
+        if not setup_rootfs(args.rootfs_path, skip_disk_check=args.skip_disk_check):
             return 1
 
         if args.skip_collection:
@@ -662,7 +663,6 @@ def main() -> int:
                     images=images,
                     csv_filepath=csv_filepath,
                     debug=args.verbose,
-                    logger=logger,
                 )
                 logger.info("Image analysis completed")
             else:
@@ -822,7 +822,6 @@ def main() -> int:
                 images=image_dicts,
                 csv_filepath=csv_filepath,
                 debug=args.verbose,
-                logger=logger,
             )
             logger.info("Image analysis completed")
         else:

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -320,25 +320,30 @@ def setup_logging(log_to_file: bool, log_file: str, verbose: bool) -> logging.Lo
     """
     Set up logging configuration.
 
+    The file handler always logs at DEBUG level so the log file captures
+    the same detail as ``-v`` stdout output.  The ``-v`` flag only controls
+    whether a StreamHandler is attached for console output.
+
     Args:
         log_to_file: Whether to enable file logging.
         log_file: Path to the log file.
-        verbose: Whether to enable verbose (DEBUG) logging.
+        verbose: Whether to enable verbose (DEBUG) logging to stdout.
 
     Returns:
         Configured logger instance.
     """
     logger = logging.getLogger("image-cgroupsv2-inspector")
-    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.setLevel(logging.DEBUG)
 
-    # Log format
-    log_format = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    file_format = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
     if log_to_file:
-        # File handler
         file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
-        file_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
-        file_handler.setFormatter(log_format)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(file_format)
         logger.addHandler(file_handler)
         print(f"📝 Logging to file: {log_file}")
 
@@ -370,28 +375,27 @@ def setup_rootfs(rootfs_path: str, logger: logging.Logger | None = None, skip_di
     Returns:
         True if successful, False otherwise.
     """
+    _log = logger or logging.getLogger("image-cgroupsv2-inspector")
     print(f"\n🔧 Setting up rootfs directory at: {rootfs_path}")
-    if logger:
-        logger.info(f"Setting up rootfs directory at: {rootfs_path}")
+    _log.info("Setting up rootfs directory at: %s", rootfs_path)
 
     manager = RootFSManager(rootfs_path)
 
-    # Create rootfs directory with ACLs (includes validation)
     success, msg = manager.create_rootfs_directory(skip_disk_check=skip_disk_check)
     if not success:
         print(f"✗ Failed to create rootfs: {msg}")
-        if logger:
-            logger.error(f"Failed to create rootfs: {msg}")
+        _log.error("Failed to create rootfs: %s", msg)
         return False
 
     print(f"\n✓ {msg}")
-    if logger:
-        logger.info(f"Rootfs setup successful: {msg}")
+    _log.info("Rootfs setup successful: %s", msg)
     return True
 
 
 def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None = None) -> None:
     """Print analysis summary from image record dicts."""
+    _log = logging.getLogger("image-cgroupsv2-inspector")
+
     java_found = sum(1 for img in images if img.get("java_binary", "None") != "None")
     node_found = sum(1 for img in images if img.get("node_binary", "None") != "None")
     dotnet_found = sum(1 for img in images if img.get("dotnet_binary", "None") != "None")
@@ -404,6 +408,13 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
     dotnet_compat = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "Yes")
     dotnet_incompat = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "No")
     dotnet_unknown = sum(1 for img in images if img.get("dotnet_cgroup_v2_compatible") == "Unknown")
+
+    _log.debug("Analysis Results: Java found=%d (compat=%d, incompat=%d, unknown=%d), "
+               "Node.js found=%d (compat=%d, incompat=%d, unknown=%d), "
+               ".NET found=%d (compat=%d, incompat=%d, unknown=%d)",
+               java_found, java_compat, java_incompat, java_unknown,
+               node_found, node_compat, node_incompat, node_unknown,
+               dotnet_found, dotnet_compat, dotnet_incompat, dotnet_unknown)
 
     print("\n   🔬 Analysis Results:")
     print(f"      Java found in: {java_found} containers")
@@ -427,6 +438,7 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
     deep_scan_found = sum(1 for img in images if img.get("deep_scan_match") == "true")
     if deep_scan_found > 0 or any(img.get("deep_scan_match") != "" for img in images):
         print(f"      Deep-scan matches: {deep_scan_found} images with cgroup v1 references")
+        _log.debug("Deep-scan matches: %d images with cgroup v1 references", deep_scan_found)
         high = sum(1 for img in images if img.get("deep_scan_confidence") == "high")
         medium = sum(1 for img in images if img.get("deep_scan_confidence") == "medium")
         low = sum(1 for img in images if img.get("deep_scan_confidence") == "low")
@@ -436,18 +448,22 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
             print(f"        ⚠ medium confidence: {medium}")
         if low:
             print(f"        ⚠ low confidence: {low}")
+        _log.debug("Deep-scan confidence breakdown: high=%d, medium=%d, low=%d", high, medium, low)
         v2_aware_count = sum(1 for img in images if img.get("deep_scan_v2_aware") == "true")
         if v2_aware_count:
             print(f"        ✓ v2-aware (dual v1+v2 support): {v2_aware_count}")
         v1_only = deep_scan_found - v2_aware_count
         if v1_only > 0:
             print(f"        ✗ v1-only (likely incompatible): {v1_only}")
+        _log.debug("Deep-scan: v2-aware=%d, v1-only=%d", v2_aware_count, v1_only)
         go_libs_count = sum(
             1 for img in images if img.get("deep_scan_go_cgroup_libs", "") != ""
         )
         if go_libs_count:
+            _log.debug("Go cgroup libraries detected in %d images", go_libs_count)
             print(f"        📦 Go cgroup libraries detected: {go_libs_count} images")
     skipped_count = len(skipped_images) if skipped_images else 0
+    _log.debug("Images skipped (timeout): %d", skipped_count)
     print(f"      Images skipped (timeout): {skipped_count}")
 
 
@@ -485,21 +501,16 @@ def main() -> int:
     log_to_file = args.log_to_file or args.log_file != "image-cgroupsv2-inspector.log"
     logger = setup_logging(log_to_file, args.log_file, args.verbose)
 
-    if log_to_file:
-        logger.info("=" * 60)
-        logger.info("image-cgroupsv2-inspector started")
-        logger.info("=" * 60)
+    logger.info("=" * 60)
+    logger.info("image-cgroupsv2-inspector started")
+    logger.info("=" * 60)
 
-    # Run system checks (podman, etc.)
-    if log_to_file:
-        logger.info("Running system checks...")
+    logger.info("Running system checks...")
     if not run_system_checks(verbose=args.verbose, deep_scan=args.deep_scan):
         print("\n✗ System checks failed. Please install the required dependencies.")
-        if log_to_file:
-            logger.error("System checks failed")
+        logger.error("System checks failed")
         return 1
-    if log_to_file:
-        logger.info("System checks passed")
+    logger.info("System checks passed")
 
     # Load .env early so env vars are available for both modes
     from dotenv import load_dotenv
@@ -510,13 +521,12 @@ def main() -> int:
 
     # Handle rootfs path if provided
     if args.rootfs_path:
-        if not setup_rootfs(args.rootfs_path, logger if log_to_file else None, skip_disk_check=args.skip_disk_check):
+        if not setup_rootfs(args.rootfs_path, logger, skip_disk_check=args.skip_disk_check):
             return 1
 
         if args.skip_collection:
             print("\n✓ Rootfs setup complete. Skipping image collection.")
-            if log_to_file:
-                logger.info("Rootfs setup complete. Skipping image collection.")
+            logger.info("Rootfs setup complete. Skipping image collection.")
             return 0
 
     # Registry mode env var fallback
@@ -562,8 +572,7 @@ def main() -> int:
         state_file_path = _build_state_file_path(registry_host, state_dir)
 
         print(f"\n🔌 Connecting to Quay registry: {args.registry_url}")
-        if log_to_file:
-            logger.info(f"Connecting to Quay registry: {args.registry_url}")
+        logger.info("Connecting to Quay registry: %s", args.registry_url)
         try:
             quay_client = QuayClient(
                 base_url=args.registry_url,
@@ -573,12 +582,10 @@ def main() -> int:
             quay_client.test_connection()
             quay_client.get_organization(args.registry_org)
             print(f"✓ Connected to Quay registry, organization: {args.registry_org}")
-            if log_to_file:
-                logger.info(f"Connected to Quay registry, organization: {args.registry_org}")
+            logger.info("Connected to Quay registry, organization: %s", args.registry_org)
         except QuayClientError as e:
             print(f"\n✗ Quay connection error: {e}")
-            if log_to_file:
-                logger.error(f"Quay connection error: {e}")
+            logger.error("Quay connection error: %s", e)
             return 1
 
         try:
@@ -604,37 +611,32 @@ def main() -> int:
 
             if not images:
                 print("\n⚠ No images found in the registry.")
-                if log_to_file:
-                    logger.warning("No images found in the registry")
+                logger.warning("No images found in the registry")
                 return 0
 
             if args.deep_scan and not args.analyze:
                 print("\n✗ Error: --deep-scan requires --analyze to be specified.")
-                if log_to_file:
-                    logger.error("--deep-scan requires --analyze")
+                logger.error("--deep-scan requires --analyze")
                 return 1
 
             if args.analyze:
                 if not args.rootfs_path:
                     print("\n✗ Error: --analyze requires --rootfs-path.")
-                    if log_to_file:
-                        logger.error("--analyze requires --rootfs-path")
+                    logger.error("--analyze requires --rootfs-path")
                     return 1
 
                 pull_secret_explicitly_set = args.pull_secret != ".pull-secret"
                 if pull_secret_explicitly_set and Path(args.pull_secret).exists():
                     pull_secret_path = args.pull_secret
                     print(f"🔑 Using pull-secret: {pull_secret_path}")
-                    if log_to_file:
-                        logger.info(f"Using pull-secret: {pull_secret_path}")
+                    logger.info("Using pull-secret: %s", pull_secret_path)
                 else:
                     pull_secret_path = generate_registry_auth_json(
                         registry_host=registry_host,
                         token=args.registry_token,
                     )
                     print(f"🔑 Generated registry auth file: {pull_secret_path}")
-                    if log_to_file:
-                        logger.info(f"Generated registry auth file: {pull_secret_path}")
+                    logger.info("Generated registry auth file: %s", pull_secret_path)
 
                 manager = RootFSManager(args.rootfs_path)
                 rootfs_path = str(manager.get_rootfs_path().parent)
@@ -646,8 +648,7 @@ def main() -> int:
                 output_path.mkdir(parents=True, exist_ok=True)
                 csv_filepath = str(output_path / f"{registry_host}-{args.registry_org}-{timestamp}.csv")
 
-                if log_to_file:
-                    logger.info("Starting image analysis...")
+                logger.info("Starting image analysis...")
                 orchestrator = AnalysisOrchestrator(
                     rootfs_path=rootfs_path,
                     pull_secret_path=pull_secret_path,
@@ -661,53 +662,49 @@ def main() -> int:
                     images=images,
                     csv_filepath=csv_filepath,
                     debug=args.verbose,
-                    logger=logger if log_to_file else None,
+                    logger=logger,
                 )
-                if log_to_file:
-                    logger.info("Image analysis completed")
+                logger.info("Image analysis completed")
             else:
                 csv_path = registry_collector.save_to_csv(images, output_dir=args.output_dir)
                 skipped = []
-                if log_to_file:
-                    logger.info(f"Results saved to CSV: {csv_path}")
+                logger.info("Results saved to CSV: %s", csv_path)
 
-            # Summary (registry mode)
             print("\n📊 Summary:")
             print(f"   Source: Quay registry ({registry_host})")
             print(f"   Organization: {args.registry_org}")
             print(f"   Total images: {len(images)}")
             unique_count = len({img["image_name"] for img in images})
             print(f"   Unique images: {unique_count}")
+            logger.debug("Summary: source=Quay registry (%s), org=%s, total=%d, unique=%d",
+                         registry_host, args.registry_org, len(images), unique_count)
 
             if args.analyze:
                 _print_analysis_summary(images, skipped)
 
             print(f"\n   Output file: {csv_path}")
+            logger.debug("Output file: %s", csv_path)
 
         except Exception as e:
             print(f"\n✗ Error during registry scan: {e}")
-            if log_to_file:
-                logger.error(f"Error during registry scan: {e}")
+            logger.error("Error during registry scan: %s", e)
             if args.verbose:
                 import traceback
 
                 traceback.print_exc()
-                if log_to_file:
-                    logger.exception("Full traceback:")
+            logger.exception("Full traceback:")
             return 1
 
-        if log_to_file:
-            logger.info("=" * 60)
-            logger.info("image-cgroupsv2-inspector completed successfully")
-            logger.info("=" * 60)
+        logger.info("=" * 60)
+        logger.info("image-cgroupsv2-inspector completed successfully")
+        logger.info("=" * 60)
 
         print("\n✓ Done!")
         return 2 if skipped else 0
 
     # ── OpenShift mode ───────────────────────────────────────────
     try:
-        if log_to_file:
-            logger.info("Creating OpenShift client...")
+        logger.info("Creating OpenShift client...")
         client = OpenShiftClient(
             api_url=args.api_url,
             token=args.token,
@@ -721,16 +718,13 @@ def main() -> int:
             print("  Please provide --api-url and --token, or set them in .env file.")
             print("\n  To get a token, run: oc whoami -t")
             print("  To get the API URL, run: oc whoami --show-server")
-            if log_to_file:
-                logger.error("OpenShift credentials not provided")
+            logger.error("OpenShift credentials not provided")
             return 1
 
         print("\n🔌 Connecting to OpenShift cluster...")
-        if log_to_file:
-            logger.info(f"Connecting to OpenShift cluster at {client.api_url}")
+        logger.info("Connecting to OpenShift cluster at %s", client.api_url)
         client.connect()
-        if log_to_file:
-            logger.info(f"Connected successfully to cluster: {client.cluster_name}")
+        logger.info("Connected successfully to cluster: %s", client.cluster_name)
 
         if args.clean_state is True:
             client.disconnect()
@@ -740,68 +734,56 @@ def main() -> int:
 
     except ValueError as e:
         print(f"\n✗ Configuration error: {e}")
-        if log_to_file:
-            logger.error(f"Configuration error: {e}")
+        logger.error("Configuration error: %s", e)
         return 1
     except Exception as e:
         print(f"\n✗ Connection error: {e}")
-        if log_to_file:
-            logger.error(f"Connection error: {e}")
+        logger.error("Connection error: %s", e)
         return 1
 
     skipped: list[str] = []
 
     try:
-        # Handle namespace filtering
         if args.namespace:
             print(f"\n📋 Inspecting single namespace: {args.namespace}")
-            if log_to_file:
-                logger.info(f"Inspecting single namespace: {args.namespace}")
+            logger.info("Inspecting single namespace: %s", args.namespace)
             collector = ImageCollector(client, namespace=args.namespace)
         else:
             exclude_patterns = None
             if args.exclude_namespaces:
                 exclude_patterns = [p.strip() for p in args.exclude_namespaces.split(",") if p.strip()]
                 print(f"\n📋 Namespace exclusion patterns: {', '.join(exclude_patterns)}")
-                if log_to_file:
-                    logger.info(f"Namespace exclusion patterns: {', '.join(exclude_patterns)}")
+                logger.info("Namespace exclusion patterns: %s", ", ".join(exclude_patterns))
             collector = ImageCollector(client, exclude_namespace_patterns=exclude_patterns)
 
-        if log_to_file:
-            logger.info("Collecting container images from cluster...")
+        logger.info("Collecting container images from cluster...")
         total = collector.collect_all()
-        if log_to_file:
-            logger.info(f"Collected {total} containers")
+        logger.info("Collected %d containers", total)
 
         if total == 0:
             print("\n⚠ No containers found in the cluster.")
-            if log_to_file:
-                logger.warning("No containers found in the cluster")
+            logger.warning("No containers found in the cluster")
             return 0
 
         if args.deep_scan and not args.analyze:
             print("\n✗ Error: --deep-scan requires --analyze to be specified.")
-            if log_to_file:
-                logger.error("--deep-scan requires --analyze")
+            logger.error("--deep-scan requires --analyze")
             return 1
 
         if args.analyze:
             if not args.rootfs_path:
                 print("\n✗ Error: --analyze requires --rootfs-path to be specified.")
-                if log_to_file:
-                    logger.error("--analyze requires --rootfs-path to be specified")
+                logger.error("--analyze requires --rootfs-path to be specified")
                 return 1
 
             pull_secret_path = None
             if args.pull_secret and Path(args.pull_secret).exists():
                 pull_secret_path = args.pull_secret
                 print(f"\n🔑 Using pull-secret: {pull_secret_path}")
-                if log_to_file:
-                    logger.info(f"Using pull-secret: {pull_secret_path}")
+                logger.info("Using pull-secret: %s", pull_secret_path)
             else:
                 print("\n⚠ Warning: No pull-secret found. Some images may fail to pull.")
-                if log_to_file:
-                    logger.warning("No pull-secret found. Some images may fail to pull.")
+                logger.warning("No pull-secret found. Some images may fail to pull.")
 
             manager = RootFSManager(args.rootfs_path)
             rootfs_path = str(manager.get_rootfs_path().parent)
@@ -809,12 +791,11 @@ def main() -> int:
             if args.internal_registry_route:
                 internal_registry_route = args.internal_registry_route
                 print(f"✓ Using custom internal registry route: {internal_registry_route}")
-                if log_to_file:
-                    logger.info(f"Using custom internal registry route: {internal_registry_route}")
+                logger.info("Using custom internal registry route: %s", internal_registry_route)
             else:
                 internal_registry_route = client.get_internal_registry_route()
-                if internal_registry_route and log_to_file:
-                    logger.info(f"Auto-detected internal registry route: {internal_registry_route}")
+                if internal_registry_route:
+                    logger.info("Auto-detected internal registry route: %s", internal_registry_route)
 
             image_dicts = [img.to_dict() for img in collector.images]
 
@@ -825,8 +806,7 @@ def main() -> int:
             output_path_dir.mkdir(parents=True, exist_ok=True)
             csv_filepath = str(output_path_dir / f"{client.cluster_name}-{timestamp}.csv")
 
-            if log_to_file:
-                logger.info("Starting image analysis...")
+            logger.info("Starting image analysis...")
             orchestrator = AnalysisOrchestrator(
                 rootfs_path=rootfs_path,
                 pull_secret_path=pull_secret_path,
@@ -842,15 +822,13 @@ def main() -> int:
                 images=image_dicts,
                 csv_filepath=csv_filepath,
                 debug=args.verbose,
-                logger=logger if log_to_file else None,
+                logger=logger,
             )
-            if log_to_file:
-                logger.info("Image analysis completed")
+            logger.info("Image analysis completed")
         else:
             csv_path = collector.save_to_csv(cluster_name=client.cluster_name, output_dir=args.output_dir)
             skipped = []
-            if log_to_file:
-                logger.info(f"Results saved to CSV: {csv_path}")
+            logger.info("Results saved to CSV: %s", csv_path)
 
         # Show summary
         if not args.analyze:
@@ -866,39 +844,42 @@ def main() -> int:
         print(f"   Unique images: {len(unique_images)}")
         print(f"   Namespaces: {df['namespace'].nunique()}")
         print(f"   Object types: {df['object_type'].value_counts().to_dict()}")
+        logger.debug("Summary: total=%d, unique=%d, namespaces=%d",
+                      len(df), len(unique_images), df["namespace"].nunique())
 
         if args.analyze:
             _print_analysis_summary(image_dicts, skipped)
 
         print(f"\n   Output file: {csv_path}")
+        logger.debug("Output file: %s", csv_path)
 
         if args.verbose:
             print("\n📋 Top 10 most used images:")
             top_images = df["image_name"].value_counts().head(10)
             for img, count in top_images.items():
                 print(f"   {count:4d} × {img}")
+        logger.debug("Top 10 most used images:")
+        top_images = df["image_name"].value_counts().head(10)
+        for img, count in top_images.items():
+            logger.debug("   %4d x %s", count, img)
 
     except Exception as e:
         print(f"\n✗ Error during collection: {e}")
-        if log_to_file:
-            logger.error(f"Error during collection: {e}")
+        logger.error("Error during collection: %s", e)
         if args.verbose:
             import traceback
 
             traceback.print_exc()
-            if log_to_file:
-                logger.exception("Full traceback:")
+        logger.exception("Full traceback:")
         return 1
 
     finally:
         client.disconnect()
-        if log_to_file:
-            logger.info("Disconnected from OpenShift cluster")
+        logger.info("Disconnected from OpenShift cluster")
 
-    if log_to_file:
-        logger.info("=" * 60)
-        logger.info("image-cgroupsv2-inspector completed successfully")
-        logger.info("=" * 60)
+    logger.info("=" * 60)
+    logger.info("image-cgroupsv2-inspector completed successfully")
+    logger.info("=" * 60)
 
     print("\n✓ Done!")
     return 2 if skipped else 0

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -84,7 +84,6 @@ class AnalysisOrchestrator:
         images: list[dict],
         csv_filepath: str | None = None,
         debug: bool = False,
-        logger: logging.Logger | None = None,
     ) -> tuple[int, str | None, list[str]]:
         """Analyze images and save CSV incrementally.
 
@@ -103,7 +102,6 @@ class AnalysisOrchestrator:
             csv_filepath: Path for incremental CSV saving.
                 If None, no CSV is written (results only in dicts).
             debug: Enable debug output.
-            logger: Optional logger for file logging.
 
         Returns:
             Tuple of (images_analyzed_count, csv_filepath or None,

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -132,8 +132,7 @@ class AnalysisOrchestrator:
                 scan_state = ScanState.load(self.state_file_path)
                 if scan_state.scanned_count == 0 and scan_state.target == "":
                     print("WARNING: --resume specified but no state file found; starting full scan")
-                    if logger:
-                        logger.warning("--resume specified but no state file found; starting full scan")
+                    logger.warning("--resume specified but no state file found; starting full scan")
                     scan_state = ScanState(target=self.target, csv_filepath=csv_filepath)
                 else:
                     if scan_state.version != STATE_VERSION:
@@ -141,12 +140,11 @@ class AnalysisOrchestrator:
                             f"WARNING: state file version {scan_state.version} "
                             f"differs from current version {STATE_VERSION}; proceeding anyway"
                         )
-                        if logger:
-                            logger.warning(
-                                "State file version %d differs from current version %d",
-                                scan_state.version,
-                                STATE_VERSION,
-                            )
+                        logger.warning(
+                            "State file version %d differs from current version %d",
+                            scan_state.version,
+                            STATE_VERSION,
+                        )
                     if scan_state.csv_filepath and csv_filepath:
                         csv_filepath = scan_state.csv_filepath
 
@@ -164,12 +162,15 @@ class AnalysisOrchestrator:
                         print(f"  Retrying {scan_state.error_count} previously failed images")
                     if scan_state.timeout_count:
                         print(f"  Retrying {scan_state.timeout_count} previously timed-out images")
-                    if logger:
-                        logger.info(
-                            "Resuming: skipping %d already-scanned images (%d remaining)",
-                            len(skipped),
-                            len(remaining),
-                        )
+                    logger.info(
+                        "Resuming: skipping %d already-scanned images (%d remaining)",
+                        len(skipped),
+                        len(remaining),
+                    )
+                    if scan_state.error_count:
+                        logger.debug("Retrying %d previously failed images", scan_state.error_count)
+                    if scan_state.timeout_count:
+                        logger.debug("Retrying %d previously timed-out images", scan_state.timeout_count)
                     unique_image_names = remaining
             else:
                 scan_state = ScanState(target=self.target, csv_filepath=csv_filepath)
@@ -181,8 +182,7 @@ class AnalysisOrchestrator:
 
         for idx, image_name in enumerate(unique_image_names, 1):
             print(f"[{idx}/{total}] Analyzing: {image_name}")
-            if logger:
-                logger.info("[%d/%d] Analyzing image: %s", idx, total, image_name)
+            logger.info("[%d/%d] Analyzing image: %s", idx, total, image_name)
 
             try:
                 result = self._analyze_with_timeout(analyzer, image_name, debug=debug)
@@ -190,12 +190,11 @@ class AnalysisOrchestrator:
                 analyzed_count += 1
             except _ImageTimeout:
                 print(f"WARNING: Skipping image {image_name} — timed out after {self.image_timeout} seconds")
-                if logger:
-                    logger.warning(
-                        "Skipping image %s — timed out after %d seconds",
-                        image_name,
-                        self.image_timeout,
-                    )
+                logger.warning(
+                    "Skipping image %s — timed out after %d seconds",
+                    image_name,
+                    self.image_timeout,
+                )
                 skipped_images.append(image_name)
                 analyzer.cleanup_image(image_name, debug=debug)
                 results_cache[image_name] = ImageAnalysisResult(
@@ -205,8 +204,7 @@ class AnalysisOrchestrator:
                 )
             except Exception as exc:
                 print(f"  Error analyzing image: {exc}")
-                if logger:
-                    logger.error("Error analyzing image %s: %s", image_name, exc)
+                logger.error("Error analyzing image %s: %s", image_name, exc)
                 if debug:
                     traceback.print_exc()
                 results_cache[image_name] = ImageAnalysisResult(image_name=image_name, image_id="", error=str(exc))
@@ -227,6 +225,7 @@ class AnalysisOrchestrator:
             if csv_filepath:
                 self._save_csv(images, csv_filepath)
                 row_count = len(images)
+                logger.debug("Progress saved: %d rows", row_count)
                 print(f"\U0001f4be Progress saved: {row_count} rows")
 
         self._apply_results(images, results_cache)
@@ -235,6 +234,7 @@ class AnalysisOrchestrator:
             self._save_csv(images, csv_filepath)
 
         if skipped_images:
+            logger.debug("Skipped images (timeout): %s", ", ".join(skipped_images))
             print("\n=== Skipped images (timeout) ===")
             for name in skipped_images:
                 print(name)

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -14,8 +14,11 @@ Confidence levels:
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Cgroup v1 controller paths (directories under /sys/fs/cgroup/)
@@ -361,6 +364,7 @@ def _run_strings(file_path: Path, debug: bool = False) -> str | None:
     try:
         file_size = file_path.stat().st_size
         if file_size > _MAX_BINARY_SIZE:
+            logger.debug("Binary too large for strings: %d bytes > %d", file_size, _MAX_BINARY_SIZE)
             if debug:
                 print(f"      [DEBUG] Binary too large for strings: {file_size} bytes > {_MAX_BINARY_SIZE}")
             return None
@@ -377,19 +381,23 @@ def _run_strings(file_path: Path, debug: bool = False) -> str | None:
             timeout=120,
         )
         if result.returncode != 0:
+            logger.debug("strings command failed: %s", result.stderr[:200])
             if debug:
                 print(f"      [DEBUG] strings command failed: {result.stderr[:200]}")
             return None
         return result.stdout
     except FileNotFoundError:
+        logger.debug("'strings' command not found in PATH")
         if debug:
             print("      [DEBUG] 'strings' command not found in PATH")
         return None
     except subprocess.TimeoutExpired:
+        logger.debug("strings command timed out")
         if debug:
             print("      [DEBUG] strings command timed out")
         return None
     except Exception as e:
+        logger.debug("strings error: %s", e)
         if debug:
             print(f"      [DEBUG] strings error: {e}")
         return None
@@ -431,6 +439,7 @@ def scan_binary_strings(
     for binary_ref in binary_refs:
         resolved = _resolve_script_in_rootfs(binary_ref, extract_path)
         if resolved is None:
+            logger.debug("Could not resolve binary in rootfs: %s", binary_ref)
             if debug:
                 print(f"      [DEBUG] Could not resolve binary in rootfs: {binary_ref}")
             continue
@@ -441,10 +450,16 @@ def scan_binary_strings(
         scanned_binaries.add(real_path_str)
 
         if not _is_elf_binary(resolved):
+            logger.debug("Not an ELF binary, skipping: %s", binary_ref)
             if debug:
                 print(f"      [DEBUG] Not an ELF binary, skipping: {binary_ref}")
             continue
 
+        try:
+            size_mb = resolved.stat().st_size / (1024 * 1024)
+            logger.debug("Running strings on binary: %s (%.1f MB)", binary_ref, size_mb)
+        except OSError:
+            logger.debug("Running strings on binary: %s", binary_ref)
         if debug:
             try:
                 size_mb = resolved.stat().st_size / (1024 * 1024)
@@ -456,10 +471,10 @@ def scan_binary_strings(
         if strings_output is None:
             continue
 
-        # Check for Go cgroup library imports
         go_deps = find_go_cgroup_deps(strings_output)
         if go_deps:
             all_go_deps.extend(dep for dep in go_deps if dep not in all_go_deps)
+            logger.debug("  Found %d Go cgroup libraries: %s", len(go_deps), ", ".join(go_deps))
             if debug:
                 print(f"      [DEBUG]   Found {len(go_deps)} Go cgroup libraries: {', '.join(go_deps)}")
 
@@ -474,16 +489,20 @@ def scan_binary_strings(
                         confidence="low",
                     )
                 )
+            logger.debug("  Found %d cgroup v1 patterns in %s", len(v1_patterns), binary_ref)
             if debug:
                 print(f"      [DEBUG]   Found {len(v1_patterns)} cgroup v1 patterns in {binary_ref}")
 
             v2_patterns = find_cgroupv2_patterns(strings_output)
             if v2_patterns:
                 v2_aware = True
+                logger.debug("  Also found %d cgroup v2 patterns — v2-aware", len(v2_patterns))
                 if debug:
                     print(f"      [DEBUG]   Also found {len(v2_patterns)} cgroup v2 patterns → v2-aware")
-        elif debug:
-            print(f"      [DEBUG]   No cgroup v1 patterns found in {binary_ref}")
+        else:
+            logger.debug("  No cgroup v1 patterns found in %s", binary_ref)
+            if debug:
+                print(f"      [DEBUG]   No cgroup v1 patterns found in {binary_ref}")
 
     return matches, v2_aware, all_go_deps
 
@@ -544,6 +563,7 @@ def scan_entrypoint_scripts(
         if real_path_str in scanned_files:
             return
         if depth > _MAX_SOURCE_DEPTH:
+            logger.debug("Max source depth reached at %s", container_path)
             if debug:
                 print(f"      [DEBUG] Max source depth reached at {container_path}")
             return
@@ -551,10 +571,12 @@ def scan_entrypoint_scripts(
 
         content = _read_script_content(file_path)
         if content is None:
+            logger.debug("Cannot read script: %s", container_path)
             if debug:
                 print(f"      [DEBUG] Cannot read script: {container_path}")
             return
 
+        logger.debug("Scanning script: %s (confidence=%s, depth=%d)", container_path, confidence, depth)
         if debug:
             print(f"      [DEBUG] Scanning script: {container_path} (confidence={confidence}, depth={depth})")
 
@@ -568,12 +590,14 @@ def scan_entrypoint_scripts(
                         confidence=confidence,
                     )
                 )
+            logger.debug("  Found %d cgroup v1 patterns in %s", len(v1_patterns), container_path)
             if debug:
                 print(f"      [DEBUG]   Found {len(v1_patterns)} cgroup v1 patterns in {container_path}")
 
             v2_patterns = find_cgroupv2_patterns(content)
             if v2_patterns:
                 v2_aware = True
+                logger.debug("  Also found %d cgroup v2 patterns — v2-aware", len(v2_patterns))
                 if debug:
                     print(f"      [DEBUG]   Also found {len(v2_patterns)} cgroup v2 patterns → v2-aware")
 
@@ -609,32 +633,39 @@ def scan_entrypoint_scripts(
 
                 if binary_container_path not in _INTERPRETER_PATHS:
                     discovered_binaries.append(binary_container_path)
+                    logger.debug("  Discovered ELF binary via exec chain: %s", binary_container_path)
                     if debug:
                         print(f"      [DEBUG]   Discovered ELF binary via exec chain: {binary_container_path}")
 
     if not entrypoint_cmd:
+        logger.debug("No entrypoint/cmd to scan")
         if debug:
             print("      [DEBUG] No entrypoint/cmd to scan")
         return matches, v2_aware, discovered_binaries
 
     entrypoint_ref = entrypoint_cmd[0]
 
+    logger.debug("Entrypoint reference: %s", entrypoint_ref)
+    logger.debug("Full entrypoint+cmd: %s", entrypoint_cmd)
     if debug:
         print(f"      [DEBUG] Entrypoint reference: {entrypoint_ref}")
         print(f"      [DEBUG] Full entrypoint+cmd: {entrypoint_cmd}")
 
     if "/" not in entrypoint_ref:
+        logger.debug("Skipping non-path entrypoint: %s", entrypoint_ref)
         if debug:
             print(f"      [DEBUG] Skipping non-path entrypoint: {entrypoint_ref}")
         return matches, v2_aware, discovered_binaries
 
     resolved = _resolve_script_in_rootfs(entrypoint_ref, extract_path)
     if resolved is None:
+        logger.debug("Could not resolve entrypoint in rootfs: %s", entrypoint_ref)
         if debug:
             print(f"      [DEBUG] Could not resolve entrypoint in rootfs: {entrypoint_ref}")
         return matches, v2_aware, discovered_binaries
 
     if not _is_shell_script(resolved):
+        logger.debug("Entrypoint is not a shell script: %s", entrypoint_ref)
         if debug:
             print(f"      [DEBUG] Entrypoint is not a shell script: {entrypoint_ref}")
         return matches, v2_aware, discovered_binaries
@@ -672,6 +703,11 @@ def run_deep_scan(
         - v2_aware: True if any scanned source has both v1 and v2 patterns
         - go_cgroup_libs: list of detected Go cgroup package paths
     """
+    logger.debug("Deep scan enabled for %s", image_name)
+    logger.debug("Extract path: %s", extract_path)
+    logger.debug("ENTRYPOINT: %s", entrypoint)
+    logger.debug("CMD: %s", cmd)
+    logger.debug("Loaded %d cgroup v1 patterns", len(_PATTERN_STRINGS))
     if debug:
         print(f"      [DEBUG] Deep scan enabled for {image_name}")
         print(f"      [DEBUG] Extract path: {extract_path}")
@@ -711,6 +747,7 @@ def run_deep_scan(
         if "/" not in ref or ref.startswith("-"):
             continue
         if ref in _INTERPRETER_PATHS:
+            logger.debug("Skipping interpreter binary: %s", ref)
             if debug:
                 print(f"      [DEBUG] Skipping interpreter binary: {ref}")
             continue
@@ -723,6 +760,7 @@ def run_deep_scan(
             binary_refs.append(ref)
 
     if binary_refs:
+        logger.debug("Binary refs to scan with strings: %s", binary_refs)
         if debug:
             print(f"      [DEBUG] Binary refs to scan with strings: {binary_refs}")
         binary_matches, binary_v2_aware, go_libs = scan_binary_strings(

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -1292,21 +1292,27 @@ class ImageAnalyzer:
             if result.java_binaries:
                 for b in result.java_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
-                    compat_word = "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    compat_word = (
+                        "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    )
                     logger.debug("Java (%s): %s at %s — %s", b.runtime_type, b.version, b.path, compat_word)
                     print(f"      {compat} Java ({b.runtime_type}): {b.version} at {b.path}")
 
             if result.node_binaries:
                 for b in result.node_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
-                    compat_word = "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    compat_word = (
+                        "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    )
                     logger.debug("Node.js: %s at %s — %s", b.version, b.path, compat_word)
                     print(f"      {compat} Node.js: {b.version} at {b.path}")
 
             if result.dotnet_binaries:
                 for b in result.dotnet_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
-                    compat_word = "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    compat_word = (
+                        "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    )
                     logger.debug(".NET: %s at %s — %s", b.version, b.path, compat_word)
                     print(f"      {compat} .NET: {b.version} at {b.path}")
 
@@ -1314,7 +1320,8 @@ class ImageAnalyzer:
                 v2_note = " (v2-aware)" if result.deep_scan_v2_aware_flag else ""
                 logger.debug(
                     "Deep-scan: %d cgroup v1 reference(s) found%s",
-                    len(result.deep_scan_matches), v2_note,
+                    len(result.deep_scan_matches),
+                    v2_note,
                 )
                 print(f"      ⚠ Deep-scan: {len(result.deep_scan_matches)} cgroup v1 reference(s) found{v2_note}")
                 sources = dict.fromkeys(m.source for m in result.deep_scan_matches)

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -11,12 +11,15 @@ Supported runtimes and minimum versions for cgroup v2:
 """
 
 import contextlib
+import logging
 import os
 import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -288,11 +291,17 @@ class ImageAnalyzer:
             Tuple of (exit_code, stdout, stderr)
         """
         try:
+            logger.debug("Running: %s", " ".join(cmd))
             if debug:
                 print(f"      [DEBUG] Running: {' '.join(cmd)}")
 
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
+            logger.debug("Exit code: %d", result.returncode)
+            if result.stdout:
+                logger.debug("stdout: %s", result.stdout[:1000])
+            if result.stderr:
+                logger.debug("stderr: %s", result.stderr[-1000:])
             if debug:
                 print(f"      [DEBUG] Exit code: {result.returncode}")
                 if result.stdout:
@@ -302,10 +311,12 @@ class ImageAnalyzer:
 
             return result.returncode, result.stdout, result.stderr
         except subprocess.TimeoutExpired:
+            logger.debug("Command timed out after %ds", timeout)
             if debug:
                 print(f"      [DEBUG] Command timed out after {timeout}s")
             return -1, "", "Command timed out"
         except Exception as e:
+            logger.debug("Exception: %s", e)
             if debug:
                 print(f"      [DEBUG] Exception: {e}")
             return -1, "", str(e)
@@ -338,8 +349,10 @@ class ImageAnalyzer:
         exit_code, _stdout, stderr = self._run_command(cmd, timeout=30, debug=debug)
         if exit_code == 0:
             self._registry_logged_in = True
+            logger.debug("Logged in to internal registry: %s", self.internal_registry_route)
             print(f"    ✓ Logged in to internal registry: {self.internal_registry_route}")
             return True
+        logger.debug("Failed to login to internal registry: %s", stderr.strip())
         print(f"    ✗ Failed to login to internal registry: {stderr.strip()}")
         return False
 
@@ -404,6 +417,8 @@ class ImageAnalyzer:
             except (json.JSONDecodeError, TypeError):
                 pass
 
+        logger.debug("Image ENTRYPOINT: %s", entrypoint)
+        logger.debug("Image CMD: %s", cmd)
         if debug:
             print(f"      [DEBUG] Image ENTRYPOINT: {entrypoint}")
             print(f"      [DEBUG] Image CMD: {cmd}")
@@ -440,6 +455,7 @@ class ImageAnalyzer:
         """
         pull_name = self._rewrite_internal_registry(image_name)
         if pull_name != image_name:
+            logger.debug("Rewriting internal registry URL: %s -> %s", image_name, pull_name)
             if debug:
                 print(f"      [DEBUG] Rewriting internal registry URL: {image_name} -> {pull_name}")
             self._login_internal_registry(debug=debug)
@@ -449,11 +465,13 @@ class ImageAnalyzer:
         auth_file = self._setup_auth()
         if auth_file:
             cmd.extend(["--authfile", auth_file])
+            logger.debug("Using authfile: %s", auth_file)
             if debug:
                 print(f"      [DEBUG] Using authfile: {auth_file}")
 
         cmd.append(pull_name)
 
+        logger.debug("Pulling image...")
         if debug:
             print("      [DEBUG] Pulling image...")
 
@@ -464,6 +482,7 @@ class ImageAnalyzer:
             error_detail = error_lines[-1] if error_lines else stderr[-500:]
             return False, f"Failed to pull image: {error_detail}"
 
+        logger.debug("Pull successful")
         if debug:
             print("      [DEBUG] Pull successful")
 
@@ -482,11 +501,13 @@ class ImageAnalyzer:
         """
         tar_path = self.rootfs_path / "image-rootfs.tar"
 
+        logger.debug("Tar will be saved to: %s", tar_path)
+        logger.debug("rootfs_path: %s", self.rootfs_path)
         if debug:
             print(f"      [DEBUG] Tar will be saved to: {tar_path}")
             print(f"      [DEBUG] rootfs_path: {self.rootfs_path}")
 
-        # Create container (don't start it)
+        logger.debug("Creating container from image...")
         if debug:
             print("      [DEBUG] Creating container from image...")
 
@@ -499,11 +520,12 @@ class ImageAnalyzer:
 
         container_id = stdout.strip()
 
+        logger.debug("Container created: %s", container_id)
         if debug:
             print(f"      [DEBUG] Container created: {container_id}")
 
         try:
-            # Export container filesystem
+            logger.debug("Exporting container to tar...")
             if debug:
                 print("      [DEBUG] Exporting container to tar...")
 
@@ -519,6 +541,7 @@ class ImageAnalyzer:
             # Verify tar was created
             if tar_path.exists():
                 tar_size = tar_path.stat().st_size
+                logger.debug("Tar created: %s (%d bytes)", tar_path, tar_size)
                 if debug:
                     print(f"      [DEBUG] Tar created: {tar_path} ({tar_size} bytes)")
             else:
@@ -527,7 +550,7 @@ class ImageAnalyzer:
             return True, str(tar_path), ""
 
         finally:
-            # Always remove the container
+            logger.debug("Removing container %s...", container_id)
             if debug:
                 print(f"      [DEBUG] Removing container {container_id}...")
             self._run_command(["podman", "rm", "-f", container_id], debug=debug)
@@ -548,17 +571,19 @@ class ImageAnalyzer:
         """
         extract_path = self.rootfs_path / "extracted"
 
+        logger.debug("Extracting tar to: %s", extract_path)
         if debug:
             print(f"      [DEBUG] Extracting tar to: {extract_path}")
 
         try:
-            # Clean existing extraction
             if extract_path.exists():
+                logger.debug("Cleaning existing extraction...")
                 if debug:
                     print("      [DEBUG] Cleaning existing extraction...")
                 shutil.rmtree(extract_path, ignore_errors=True)
             extract_path.mkdir(parents=True)
 
+            logger.debug("Extracting tar file: %s", tar_path)
             if debug:
                 print(f"      [DEBUG] Extracting tar file: {tar_path}")
 
@@ -583,26 +608,22 @@ class ImageAnalyzer:
             # tar may return non-zero for minor issues but still extract most files
             # We check if extraction actually produced files
             if extract_path.exists():
-                # Fix permissions to allow reading and deletion
-                # chmod -R u+rwX adds read, write, and execute (for dirs) for owner
+                logger.debug("Fixing permissions on extracted files...")
                 if debug:
                     print("      [DEBUG] Fixing permissions on extracted files...")
 
                 chmod_cmd = ["chmod", "-R", "u+rwX", str(extract_path)]
                 self._run_command(chmod_cmd, timeout=120, debug=debug)
 
-                # Also remove any ACL restrictions that might prevent deletion
-                # setfacl -R -b removes all ACLs
                 setfacl_cmd = ["setfacl", "-R", "-b", str(extract_path)]
                 self._run_command(setfacl_cmd, timeout=120, debug=debug)
 
-                # Count extracted items
                 file_count = sum(1 for _ in extract_path.rglob("*"))
+                logger.debug("Extraction complete: %d items in %s", file_count, extract_path)
                 if debug:
                     print(f"      [DEBUG] Extraction complete: {file_count} items in {extract_path}")
 
                 if file_count > 0:
-                    # Show first few items
                     if debug:
                         items = list(extract_path.iterdir())[:10]
                         print(f"      [DEBUG] Top-level items: {[i.name for i in items]}")
@@ -613,6 +634,7 @@ class ImageAnalyzer:
                 return False, f"Extract path not created: {extract_path}"
 
         except Exception as e:
+            logger.debug("Extract error: %s", e)
             if debug:
                 print(f"      [DEBUG] Extract error: {e}")
             return False, f"Failed to extract tar: {e}"
@@ -1016,9 +1038,9 @@ class ImageAnalyzer:
             keep_image: If True, don't remove the image
             debug: Enable debug output
         """
-        # Clean rootfs
         extract_path = self.rootfs_path / "extracted"
         if extract_path.exists():
+            logger.debug("Cleaning up extracted files: %s", extract_path)
             if debug:
                 print(f"      [DEBUG] Cleaning up extracted files: {extract_path}")
 
@@ -1035,20 +1057,21 @@ class ImageAnalyzer:
             try:
                 shutil.rmtree(extract_path)
             except Exception as e:
+                logger.debug("shutil.rmtree failed: %s, trying rm -rf", e)
                 if debug:
                     print(f"      [DEBUG] shutil.rmtree failed: {e}, trying rm -rf")
-                # Fallback to rm -rf
                 self._run_command(["rm", "-rf", str(extract_path)], timeout=120)
 
         tar_path = self.rootfs_path / "image-rootfs.tar"
         if tar_path.exists():
+            logger.debug("Removing tar file: %s", tar_path)
             if debug:
                 print(f"      [DEBUG] Removing tar file: {tar_path}")
             with contextlib.suppress(Exception):
                 tar_path.unlink()
 
-        # Remove image
         if not keep_image:
+            logger.debug("Removing image: %s...", image_name[:50])
             if debug:
                 print(f"      [DEBUG] Removing image: {image_name[:50]}...")
             self._run_command(["podman", "rmi", "-f", image_name])
@@ -1078,18 +1101,22 @@ class ImageAnalyzer:
         Returns:
             ImageAnalysisResult with found binaries and versions
         """
-        # Check if already analyzed (use image_name as key if no image_id)
         cache_key = image_id if image_id else image_name
         if cache_key in self._analyzed_images:
+            logger.debug("Using cached result for %s...", image_name[:50])
             if debug:
                 print(f"      [DEBUG] Using cached result for {image_name[:50]}...")
             return self._analyzed_images[cache_key]
 
         result = ImageAnalysisResult(image_name=image_name, image_id=image_id)
 
-        # Resolve the name podman will actually use (may differ for internal registry images)
         podman_image = self._rewrite_internal_registry(image_name)
 
+        logger.debug("rootfs_base: %s", self.rootfs_base)
+        logger.debug("rootfs_path: %s", self.rootfs_path)
+        logger.debug("rootfs_path exists: %s", self.rootfs_path.exists())
+        if podman_image != image_name:
+            logger.debug("Using rewritten image for podman: %s", podman_image)
         if debug:
             print(f"      [DEBUG] rootfs_base: {self.rootfs_base}")
             print(f"      [DEBUG] rootfs_path: {self.rootfs_path}")
@@ -1098,37 +1125,42 @@ class ImageAnalyzer:
                 print(f"      [DEBUG] Using rewritten image for podman: {podman_image}")
 
         try:
+            logger.debug("Pulling image: %s...", image_name[:80])
             print(f"    Pulling image: {image_name[:80]}...")
 
-            # Pull image
             success, error = self._pull_image(image_name, debug=debug)
             if not success:
                 result.error = error
+                logger.debug("Pull failed: %s", error[:300])
                 print(f"    ✗ Pull failed: {error[:300]}")
                 return result
 
+            logger.debug("Exporting container filesystem...")
             print("    Exporting container filesystem...")
 
-            # Create and export container
             success, tar_path, error = self._create_and_export_container(podman_image, debug=debug)
             if not success:
                 result.error = error
+                logger.debug("Export failed: %s", error[:300])
                 print(f"    ✗ Export failed: {error[:300]}")
                 self._cleanup(podman_image, debug=debug)
                 return result
 
+            logger.debug("Extracting filesystem...")
             print("    Extracting filesystem...")
 
-            # Extract tar
             success, error = self._extract_tar(tar_path, debug=debug)
             if not success:
                 result.error = error
+                logger.debug("Extract failed: %s", error[:300])
                 print(f"    ✗ Extract failed: {error[:300]}")
                 self._cleanup(podman_image, debug=debug)
                 return result
 
             extract_path = self.rootfs_path / "extracted"
 
+            logger.debug("extract_path: %s", extract_path)
+            logger.debug("extract_path exists: %s", extract_path.exists())
             if debug:
                 print(f"      [DEBUG] extract_path: {extract_path}")
                 print(f"      [DEBUG] extract_path exists: {extract_path.exists()}")
@@ -1136,7 +1168,7 @@ class ImageAnalyzer:
                     items = list(extract_path.iterdir())[:5]
                     print(f"      [DEBUG] First items: {[str(i.name) for i in items]}")
 
-            # Find Java binaries
+            logger.debug("Searching for Java binaries...")
             print("    Searching for Java binaries...")
             java_paths = self._find_binaries(extract_path, self.JAVA_BINARY_PATTERN)
 
@@ -1146,19 +1178,17 @@ class ImageAnalyzer:
                 rel_path = os.path.relpath(java_path, extract_path)
                 container_path = f"/{rel_path}"
 
-                # Skip paths that are not real binaries
                 if self._is_excluded_path(container_path):
+                    logger.debug("Skipping excluded path: %s", container_path)
                     if debug:
                         print(f"      [DEBUG] Skipping excluded path: {container_path}")
                     continue
 
-                # Skip if we already checked a binary with this resolved path
                 resolved = os.path.realpath(java_path)
                 if resolved in java_checked:
                     continue
                 java_checked.add(resolved)
 
-                # Run version check inside container
                 version, output, runtime_type = self._get_java_version_in_container(
                     podman_image, container_path, debug=debug
                 )
@@ -1174,23 +1204,21 @@ class ImageAnalyzer:
                     )
                 )
 
-            # Find Node binaries
+            logger.debug("Searching for Node.js binaries...")
             print("    Searching for Node.js binaries...")
             node_paths = self._find_binaries(extract_path, self.NODE_BINARY_PATTERN)
 
-            # Deduplicate - only check unique binaries
             node_checked = set()
             for node_path in node_paths:
                 rel_path = os.path.relpath(node_path, extract_path)
                 container_path = f"/{rel_path}"
 
-                # Skip paths that are not real binaries
                 if self._is_excluded_path(container_path):
+                    logger.debug("Skipping excluded path: %s", container_path)
                     if debug:
                         print(f"      [DEBUG] Skipping excluded path: {container_path}")
                     continue
 
-                # Skip if we already checked a binary with this resolved path
                 resolved = os.path.realpath(node_path)
                 if resolved in node_checked:
                     continue
@@ -1210,23 +1238,21 @@ class ImageAnalyzer:
                     )
                 )
 
-            # Find .NET binaries
+            logger.debug("Searching for .NET binaries...")
             print("    Searching for .NET binaries...")
             dotnet_paths = self._find_binaries(extract_path, self.DOTNET_BINARY_PATTERN)
 
-            # Deduplicate - only check unique binaries
             dotnet_checked = set()
             for dotnet_path in dotnet_paths:
                 rel_path = os.path.relpath(dotnet_path, extract_path)
                 container_path = f"/{rel_path}"
 
-                # Skip paths that are not real binaries
                 if self._is_excluded_path(container_path):
+                    logger.debug("Skipping excluded path: %s", container_path)
                     if debug:
                         print(f"      [DEBUG] Skipping excluded path: {container_path}")
                     continue
 
-                # Skip if we already checked a binary with this resolved path
                 resolved = os.path.realpath(dotnet_path)
                 if resolved in dotnet_checked:
                     continue
@@ -1246,8 +1272,8 @@ class ImageAnalyzer:
                     )
                 )
 
-            # Deep scan: heuristic cgroup v1 detection
             if self.deep_scan:
+                logger.debug("Running deep-scan for cgroup v1 references...")
                 print("    Running deep-scan for cgroup v1 references...")
                 entrypoint, cmd = self._get_image_entrypoint(podman_image, debug=debug)
                 from .deep_scan import run_deep_scan
@@ -1263,38 +1289,52 @@ class ImageAnalyzer:
                 result.deep_scan_v2_aware_flag = v2_aware
                 result.deep_scan_go_cgroup_libs_list = go_libs
 
-            # Report findings
             if result.java_binaries:
                 for b in result.java_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
+                    compat_word = "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    logger.debug("Java (%s): %s at %s — %s", b.runtime_type, b.version, b.path, compat_word)
                     print(f"      {compat} Java ({b.runtime_type}): {b.version} at {b.path}")
 
             if result.node_binaries:
                 for b in result.node_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
+                    compat_word = "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    logger.debug("Node.js: %s at %s — %s", b.version, b.path, compat_word)
                     print(f"      {compat} Node.js: {b.version} at {b.path}")
 
             if result.dotnet_binaries:
                 for b in result.dotnet_binaries:
                     compat = "?" if b.is_compatible is None else ("✓" if b.is_compatible else "✗")
+                    compat_word = "unknown" if b.is_compatible is None else ("compatible" if b.is_compatible else "incompatible")
+                    logger.debug(".NET: %s at %s — %s", b.version, b.path, compat_word)
                     print(f"      {compat} .NET: {b.version} at {b.path}")
 
             if self.deep_scan and result.deep_scan_matches:
                 v2_note = " (v2-aware)" if result.deep_scan_v2_aware_flag else ""
+                logger.debug(
+                    "Deep-scan: %d cgroup v1 reference(s) found%s",
+                    len(result.deep_scan_matches), v2_note,
+                )
                 print(f"      ⚠ Deep-scan: {len(result.deep_scan_matches)} cgroup v1 reference(s) found{v2_note}")
                 sources = dict.fromkeys(m.source for m in result.deep_scan_matches)
                 for src in sources:
                     src_matches = [m for m in result.deep_scan_matches if m.source == src]
                     patterns_str = ", ".join(dict.fromkeys(m.pattern for m in src_matches))
+                    logger.debug("  [%s] %s: %s", src_matches[0].confidence, src, patterns_str)
                     print(f"        [{src_matches[0].confidence}] {src}: {patterns_str}")
                 if result.deep_scan_go_cgroup_libs_list:
+                    logger.debug("Go cgroup libraries: %s", ", ".join(result.deep_scan_go_cgroup_libs_list))
                     print(f"      📦 Go cgroup libraries: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
             elif self.deep_scan:
+                logger.debug("Deep-scan: no cgroup v1 references found")
                 print("      ✓ Deep-scan: no cgroup v1 references found")
                 if result.deep_scan_go_cgroup_libs_list:
+                    logger.debug("Go cgroup libraries detected: %s", ", ".join(result.deep_scan_go_cgroup_libs_list))
                     print(f"      📦 Go cgroup libraries detected: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
 
             if not result.java_binaries and not result.node_binaries and not result.dotnet_binaries:
+                logger.debug("No Java, Node.js, or .NET binaries found")
                 print("      No Java, Node.js, or .NET binaries found")
 
         except Exception as e:

--- a/src/image_collector.py
+++ b/src/image_collector.py
@@ -27,6 +27,8 @@ from kubernetes.client.rest import ApiException
 
 from .openshift_client import OpenShiftClient
 
+logger = logging.getLogger(__name__)
+
 # Default namespace patterns to exclude (infrastructure namespaces)
 DEFAULT_EXCLUDE_NAMESPACE_PATTERNS = ["openshift-*", "kube-*"]
 
@@ -318,6 +320,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from standalone Pods...")
         print("  Collecting images from standalone Pods...")
         core_v1 = self.client.get_core_v1_api()
         count = 0
@@ -399,8 +402,10 @@ class ImageCollector:
                 )
 
         except Exception as e:
+            logger.debug("Error collecting from Pods: %s", e)
             print(f"    Warning: Error collecting from Pods: {e}")
 
+        logger.debug("Found %d containers in standalone Pods (skipped %d managed/static pods)", count, skipped)
         print(f"    Found {count} containers in standalone Pods (skipped {skipped} managed/static pods)")
         return count
 
@@ -414,6 +419,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from Deployments...")
         print("  Collecting images from Deployments...")
         apps_v1 = self.client.get_apps_v1_api()
         count = 0
@@ -453,8 +459,10 @@ class ImageCollector:
                 )
 
         except Exception as e:
+            logger.debug("Error collecting from Deployments: %s", e)
             print(f"    Warning: Error collecting from Deployments: {e}")
 
+        logger.debug("Found %d containers in Deployments", count)
         print(f"    Found {count} containers in Deployments")
         return count
 
@@ -467,6 +475,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from StatefulSets...")
         print("  Collecting images from StatefulSets...")
         apps_v1 = self.client.get_apps_v1_api()
         count = 0
@@ -503,8 +512,10 @@ class ImageCollector:
                 )
 
         except Exception as e:
+            logger.debug("Error collecting from StatefulSets: %s", e)
             print(f"    Warning: Error collecting from StatefulSets: {e}")
 
+        logger.debug("Found %d containers in StatefulSets", count)
         print(f"    Found {count} containers in StatefulSets")
         return count
 
@@ -517,6 +528,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from DaemonSets...")
         print("  Collecting images from DaemonSets...")
         apps_v1 = self.client.get_apps_v1_api()
         count = 0
@@ -553,8 +565,10 @@ class ImageCollector:
                 )
 
         except Exception as e:
+            logger.debug("Error collecting from DaemonSets: %s", e)
             print(f"    Warning: Error collecting from DaemonSets: {e}")
 
+        logger.debug("Found %d containers in DaemonSets", count)
         print(f"    Found {count} containers in DaemonSets")
         return count
 
@@ -568,6 +582,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from DeploymentConfigs...")
         print("  Collecting images from DeploymentConfigs...")
         count = 0
         skipped_ns = 0
@@ -620,12 +635,16 @@ class ImageCollector:
 
         except ApiException as e:
             if e.status == 404:
+                logger.debug("DeploymentConfig API not available (apps.openshift.io not installed, skipping)")
                 print("    DeploymentConfig API not available (apps.openshift.io not installed, skipping)")
             else:
+                logger.debug("Error collecting from DeploymentConfigs: %s", e)
                 print(f"    Warning: Error collecting from DeploymentConfigs: {e}")
         except Exception as e:
+            logger.debug("Error collecting from DeploymentConfigs: %s", e)
             print(f"    Warning: Error collecting from DeploymentConfigs: {e}")
 
+        logger.debug("Found %d containers in DeploymentConfigs", count)
         print(f"    Found {count} containers in DeploymentConfigs")
         return count
 
@@ -638,6 +657,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from standalone Jobs...")
         print("  Collecting images from standalone Jobs...")
         batch_v1 = self.client.get_batch_v1_api()
         count = 0
@@ -677,8 +697,10 @@ class ImageCollector:
                 )
 
         except Exception as e:
+            logger.debug("Error collecting from Jobs: %s", e)
             print(f"    Warning: Error collecting from Jobs: {e}")
 
+        logger.debug("Found %d containers in standalone Jobs (skipped %d CronJob-managed)", count, skipped)
         print(f"    Found {count} containers in standalone Jobs (skipped {skipped} CronJob-managed)")
         return count
 
@@ -691,6 +713,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from CronJobs...")
         print("  Collecting images from CronJobs...")
         batch_v1 = self.client.get_batch_v1_api()
         count = 0
@@ -723,8 +746,10 @@ class ImageCollector:
                 count += self._add_container_info(all_containers, namespace, "CronJob", cj_name)
 
         except Exception as e:
+            logger.debug("Error collecting from CronJobs: %s", e)
             print(f"    Warning: Error collecting from CronJobs: {e}")
 
+        logger.debug("Found %d containers in CronJobs", count)
         print(f"    Found {count} containers in CronJobs")
         return count
 
@@ -737,6 +762,7 @@ class ImageCollector:
         Returns:
             Number of containers found.
         """
+        logger.debug("Collecting images from standalone ReplicaSets...")
         print("  Collecting images from standalone ReplicaSets...")
         apps_v1 = self.client.get_apps_v1_api()
         count = 0
@@ -784,8 +810,10 @@ class ImageCollector:
                 )
 
         except Exception as e:
+            logger.debug("Error collecting from ReplicaSets: %s", e)
             print(f"    Warning: Error collecting from ReplicaSets: {e}")
 
+        logger.debug("Found %d containers in standalone ReplicaSets (skipped %d managed/empty)", count, skipped)
         print(f"    Found {count} containers in standalone ReplicaSets (skipped {skipped} managed/empty)")
         return count
 
@@ -802,11 +830,15 @@ class ImageCollector:
             Total number of containers found.
         """
         if self.namespace:
+            logger.debug("Collecting container images from namespace: %s", self.namespace)
             print(f"\n📦 Collecting container images from namespace: {self.namespace}")
         else:
+            logger.debug("Collecting container images from cluster...")
             print("\n📦 Collecting container images from cluster...")
+        logger.debug("Only top-level controllers are reported, child objects are skipped")
         print("  (Only top-level controllers are reported, child objects are skipped)")
         if self.exclude_patterns:
+            logger.debug("Excluding namespaces matching: %s", ", ".join(self.exclude_patterns))
             print(f"  (Excluding namespaces matching: {', '.join(self.exclude_patterns)})")
         self.images = []  # Reset
         self._excluded_namespaces_cache.clear()  # Clear cache for fresh collection
@@ -827,8 +859,15 @@ class ImageCollector:
         # 3. Pods (only standalone)
         total += self.collect_from_pods()  # Skip all controller-managed
 
+        logger.debug("Total containers found: %d", total)
         print(f"\n✓ Total containers found: {total}")
         if self._excluded_namespaces_cache:
+            logger.debug(
+                "Excluded %d namespaces: %s%s",
+                len(self._excluded_namespaces_cache),
+                ", ".join(sorted(self._excluded_namespaces_cache)[:5]),
+                "..." if len(self._excluded_namespaces_cache) > 5 else "",
+            )
             print(
                 f"  (Excluded {len(self._excluded_namespaces_cache)} namespaces: {', '.join(sorted(self._excluded_namespaces_cache)[:5])}{'...' if len(self._excluded_namespaces_cache) > 5 else ''})"
             )
@@ -893,6 +932,7 @@ class ImageCollector:
         df = self.to_dataframe()
         df.to_csv(filepath, index=False)
 
+        logger.debug("Saved %d records to %s", len(df), filepath)
         print(f"\n✓ Saved {len(df)} records to {filepath}")
         return str(filepath)
 

--- a/src/openshift_client.py
+++ b/src/openshift_client.py
@@ -5,6 +5,7 @@ Handles connection to OpenShift cluster via API URL and token.
 
 import base64
 import json
+import logging
 import os
 from pathlib import Path
 from urllib.parse import urlparse
@@ -14,6 +15,8 @@ from dotenv import load_dotenv, set_key
 from kubernetes import client
 from kubernetes.client import ApiClient, Configuration
 from kubernetes.client.rest import ApiException
+
+logger = logging.getLogger(__name__)
 
 # Disable SSL warnings for self-signed certificates
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -111,17 +114,16 @@ class OpenShiftClient:
         try:
             version_api = client.VersionApi(self._api_client)
             version_info = version_api.get_code()
+            logger.debug("Connected to OpenShift cluster")
+            logger.debug("Kubernetes version: %s", version_info.git_version)
             print("✓ Connected to OpenShift cluster")
             print(f"  Kubernetes version: {version_info.git_version}")
 
-            # Extract and store cluster name
             self._cluster_name = self._extract_cluster_name()
+            logger.debug("Cluster name: %s", self._cluster_name)
             print(f"  Cluster name: {self._cluster_name}")
 
-            # Save credentials to .env file
             self._save_to_env()
-
-            # Download and save pull-secret
             self._download_pull_secret()
 
             return True
@@ -139,6 +141,7 @@ class OpenShiftClient:
         # Save credentials
         set_key(str(self.env_file), "OPENSHIFT_API_URL", self.api_url)
         set_key(str(self.env_file), "OPENSHIFT_TOKEN", self.token)
+        logger.debug("Credentials saved to %s", self.env_file)
         print(f"✓ Credentials saved to {self.env_file}")
 
     def _download_pull_secret(self) -> bool:
@@ -153,6 +156,7 @@ class OpenShiftClient:
             True if successful, False otherwise.
         """
         if self.pull_secret_file.exists():
+            logger.debug("Pull secret already exists at %s, skipping download", self.pull_secret_file)
             print(f"✓ Pull secret already exists at {self.pull_secret_file}, skipping download")
             return True
 
@@ -178,21 +182,27 @@ class OpenShiftClient:
                 # Set restrictive permissions (readable only by owner)
                 os.chmod(self.pull_secret_file, 0o600)
 
+                logger.debug("Pull secret saved to %s", self.pull_secret_file)
                 print(f"✓ Pull secret saved to {self.pull_secret_file}")
                 return True
             else:
+                logger.debug("Pull secret found but no .dockerconfigjson data")
                 print("⚠ Pull secret found but no .dockerconfigjson data")
                 return False
 
         except ApiException as e:
             if e.status == 403:
+                logger.debug("No permission to read pull-secret (requires cluster-admin)")
                 print("⚠ No permission to read pull-secret (requires cluster-admin)")
             elif e.status == 404:
+                logger.debug("Pull secret not found in openshift-config namespace")
                 print("⚠ Pull secret not found in openshift-config namespace")
             else:
+                logger.debug("Failed to download pull-secret: %s", e.reason)
                 print(f"⚠ Failed to download pull-secret: {e.reason}")
             return False
         except Exception as e:
+            logger.debug("Error downloading pull-secret: %s", e)
             print(f"⚠ Error downloading pull-secret: {e}")
             return False
 
@@ -248,16 +258,21 @@ class OpenShiftClient:
             )
             host = route.get("spec", {}).get("host", "")
             if host:
+                logger.debug("Internal registry route: %s", host)
                 print(f"✓ Internal registry route: {host}")
                 return host
         except ApiException as e:
             if e.status == 404:
+                logger.debug("Internal registry default-route not found (not exposed)")
                 print("⚠ Internal registry default-route not found (not exposed)")
             elif e.status == 403:
+                logger.debug("No permission to read internal registry route")
                 print("⚠ No permission to read internal registry route")
             else:
+                logger.debug("Error querying internal registry route: %s", e.reason)
                 print(f"⚠ Error querying internal registry route: {e.reason}")
         except Exception as e:
+            logger.debug("Error querying internal registry route: %s", e)
             print(f"⚠ Error querying internal registry route: {e}")
         return None
 
@@ -266,4 +281,5 @@ class OpenShiftClient:
         if self._api_client:
             self._api_client.close()
             self._api_client = None
+            logger.debug("Disconnected from OpenShift cluster")
             print("✓ Disconnected from OpenShift cluster")

--- a/src/system_checks.py
+++ b/src/system_checks.py
@@ -3,8 +3,11 @@ System Checks Module
 Verifies system requirements for the image inspector tool.
 """
 
+import logging
 import shutil
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 
 def check_podman_installed() -> tuple[bool, str]:
@@ -100,30 +103,35 @@ def run_system_checks(verbose: bool = False, deep_scan: bool = False) -> bool:
     Returns:
         True if all checks pass, False otherwise.
     """
+    logger.debug("Running system checks...")
     print("\n🔍 Running system checks...")
     all_passed = True
 
-    # Check podman
     podman_installed, msg = check_podman_installed()
     if podman_installed:
+        logger.debug("Podman check passed: %s", msg)
         print(f"✓ {msg}")
 
         if verbose:
             podman_running, run_msg = check_podman_running()
             if podman_running:
+                logger.debug("Podman functional: %s", run_msg)
                 print(f"✓ {run_msg}")
             else:
+                logger.debug("Podman not functional: %s", run_msg)
                 print(f"⚠ {run_msg}")
     else:
+        logger.debug("Podman check failed: %s", msg)
         print(f"✗ {msg}")
         all_passed = False
 
-    # Check strings (only needed for --deep-scan)
     if deep_scan:
         strings_installed, msg = check_strings_installed()
         if strings_installed:
+            logger.debug("Strings check passed: %s", msg)
             print(f"✓ {msg}")
         else:
+            logger.debug("Strings check failed: %s", msg)
             print(f"✗ {msg}")
             all_passed = False
 


### PR DESCRIPTION
The log file now captures the same detailed, step-by-step information that -v prints to stdout. The file handler always logs at DEBUG level regardless of the -v flag, so every run produces a full-detail log. Changes:
- setup_logging(): file handler always at DEBUG, formatter includes module.funcName for traceability
- Added module-level loggers to image_analyzer, deep_scan, image_collector, openshift_client, system_checks
- Every verbose print() now has a matching logger.debug() call
- Removed all `if log_to_file:` / `if logger:` guards in the CLI and orchestrator — logging calls are now unconditional
- No new CLI flags; no change to -v stdout behavior