### PR TITLE
Add automatic cgroups v2 compliance detection for Go binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,9 +623,12 @@ When the deep-scan finds cgroup v1 patterns in a file that **also** contains cgr
 | `deep_scan_match` | `deep_scan_v2_aware` | Action |
 |----|----|----|
 | `false` | (empty) | No cgroup v1 references found — image is fine |
-| `true` | `true` | v1 references found but image handles both v1 and v2 — likely safe |
+| `true` | `v2_compliant` | Go binary: all v1 patterns covered by v2-aware libraries (safe to migrate) |
+| `true` | `v2_likely_compliant` | Go binary: v2 indicators found but cannot fully verify coverage (low risk) |
+| `true` | `needs_review` | Go binary: partial v2 awareness detected, manual verification needed |
+| `true` | `v2_unaware` | Go binary: no v2 awareness detected (OOMKill risk on cgroups v2) |
+| `true` | `true` | Non-Go: v1 references found but v2 patterns also present — likely safe |
 | `true` | `false` | v1 references found with no v2 fallback — **investigate and remediate** |
-| `false` | (empty) | No direct v1 patterns but binary uses Go cgroup libraries — investigate |
 
 #### Source Chain Following
 
@@ -651,7 +654,37 @@ Go binaries compiled with static linking embed the full import paths of all depe
 - `go.uber.org/automaxprocs` — auto-tuning GOMAXPROCS from cgroup CPU limits
 - `github.com/KimMachineGun/automemlimit` — auto-tuning memory limits from cgroups
 
-These are reported in the `deep_scan_go_cgroup_libs` CSV column as an informational signal. Finding a library does **not** set `deep_scan_match=true` — the library might be used in v2-compatible mode. The column helps operators identify binaries that likely interact with cgroups even when no direct v1 path patterns were found.
+These are reported in the `deep_scan_go_cgroup_libs` CSV column (with versions when available) as an informational signal. Finding a library does **not** set `deep_scan_match=true` — the library might be used in v2-compatible mode. The column helps operators identify binaries that likely interact with cgroups even when no direct v1 path patterns were found.
+
+#### Automatic Go v2 Compliance Detection
+
+When the deep-scan finds cgroup v1 patterns in a Go binary that also uses known cgroup libraries, the tool automatically checks whether the binary is **v2 compliant** — meaning it has v1 references but also has proven v2-aware code paths from libraries that fully support cgroups v2.
+
+The detection works by:
+1. Scanning for **v2 awareness indicators** in the binary (e.g., `isCGroupV2`, `CGroups2`, `cgroups2.go`, `cpu.max`, `memory.max`)
+2. Extracting **Go module versions** from embedded build info (Go 1.18+ embeds `dep` lines)
+3. Checking whether the detected library version meets the **minimum v2-support version**
+4. Determining whether all v1 patterns are **covered** by v2-aware libraries
+
+**Compliance status values:**
+
+| Status | Meaning |
+|--------|---------|
+| `v2_compliant` | All v1 patterns are covered by v2-aware libraries with sufficient versions. Safe to migrate to cgroups v2 |
+| `v2_likely_compliant` | v2 indicators found but cannot fully verify coverage of all v1 patterns. Low risk |
+| `needs_review` | Partial v2 awareness detected — some patterns uncovered, or library version unknown. Manual verification needed |
+| `v2_unaware` | No v2 awareness indicators and no known cgroup libraries detected. High risk on cgroups v2 systems |
+
+**Known v2-aware Go libraries:**
+
+| Library | Min v2 Version | Patterns Covered |
+|---------|---------------|-----------------|
+| `go.uber.org/automaxprocs` | v1.5.0 | `cpu.cfs_quota_us`, `cpu.cfs_period_us` |
+| `github.com/containerd/cgroups` | v1.0.0 | `cpu.cfs_quota_us`, `cpu.cfs_period_us`, `memory.limit_in_bytes`, `cpuacct` |
+| `github.com/opencontainers/runc/libcontainer/cgroups` | v1.1.0 | `cpu.cfs_quota_us`, `cpu.cfs_period_us`, `memory.limit_in_bytes`, `cpuacct` |
+| `github.com/prometheus/procfs` | v0.8.0 | *(none — reads /proc, cgroup-neutral)* |
+
+This enhancement only applies to Go binaries. Java, Node.js, and .NET have their own version-based detection and are not affected.
 
 #### Deep Scan Example
 
@@ -737,8 +770,9 @@ The tool generates a CSV file in the `output` directory (or the path specified b
 | `deep_scan_confidence` | Highest confidence level: `"high"`, `"medium"`, or `"low"` (empty if no match) |
 | `deep_scan_sources` | Pipe-separated file paths where matches were found (e.g., `/entrypoint.sh\|/opt/helpers.sh` or `binary:/usr/bin/cadvisor`) |
 | `deep_scan_patterns` | Pipe-separated cgroup v1 patterns matched (e.g., `memory.limit_in_bytes\|cpu.cfs_quota_us`) |
-| `deep_scan_v2_aware` | `"true"` if matched files also contain cgroup v2 patterns, `"false"` if v1-only, empty if no match |
-| `deep_scan_go_cgroup_libs` | Pipe-separated Go package paths that interact with cgroups (e.g., `github.com/prometheus/procfs\|github.com/containerd/cgroups`). Informational — these libraries may use v1 or v2 |
+| `deep_scan_v2_aware` | cgroups v2 compliance status. For Go binaries: `"v2_compliant"`, `"v2_likely_compliant"`, `"needs_review"`, or `"v2_unaware"`. For non-Go sources: `"true"` if v2 patterns also found, `"false"` if v1-only. Empty if no match |
+| `deep_scan_go_cgroup_libs` | Pipe-separated Go package paths with versions when available (e.g., `go.uber.org/automaxprocs v1.5.1\|github.com/prometheus/procfs v0.7.3`). Informational — these libraries may use v1 or v2 |
+| `deep_scan_compliance_note` | Human-readable explanation of Go v2 compliance determination. Empty if not a Go binary or no compliance check performed |
 | `analysis_error` | Error message if analysis failed |
 
 ### Identifying Incompatible Images
@@ -760,12 +794,13 @@ Possible values for these fields:
 When `--deep-scan` is enabled, these additional fields help identify images with cgroup v1 dependencies:
 
 - **`deep_scan_match`**: If `"true"`, the image contains cgroup v1 references in its entrypoint scripts or binaries
-- **`deep_scan_v2_aware`**: If `"false"` (with `deep_scan_match=true`), the image has v1 references **without** v2 fallback logic — these are the highest priority for remediation
-- **`deep_scan_confidence`**: Indicates how reliable the finding is (`high` > `medium` > `low`)
+- **`deep_scan_v2_aware`**: Compliance status for Go binaries (`"v2_compliant"`, `"v2_likely_compliant"`, `"needs_review"`, `"v2_unaware"`) or boolean for non-Go (`"true"`/`"false"`). The highest priority for remediation are `"false"` and `"v2_unaware"` entries
+- **`deep_scan_confidence`**: Indicates how reliable the finding is (`high` > `medium` > `low`). When a Go binary is `v2_compliant`, confidence is automatically upgraded to `high`
+- **`deep_scan_compliance_note`**: Explanation of the Go v2 compliance determination (e.g., which library covers which patterns)
 
 To find the most critical images, filter for:
 ```csv
-deep_scan_match == "true" AND deep_scan_v2_aware == "false"
+deep_scan_match == "true" AND deep_scan_v2_aware IN ("false", "v2_unaware", "needs_review")
 ```
 
 ### Filename Format

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -300,3 +300,4 @@ class AnalysisOrchestrator:
                 record["deep_scan_patterns"] = result.deep_scan_patterns
                 record["deep_scan_v2_aware"] = result.deep_scan_v2_aware
                 record["deep_scan_go_cgroup_libs"] = result.deep_scan_go_cgroup_libs
+                record["deep_scan_compliance_note"] = result.deep_scan_compliance_note

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -217,6 +217,216 @@ def find_go_cgroup_deps(text: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Go cgroups v2 compliance detection
+# ---------------------------------------------------------------------------
+
+V2_AWARENESS_INDICATORS = (
+    # automaxprocs v2 detection function
+    "isCGroupV2",
+    # CGroups2 struct/type
+    "CGroups2",
+    "NewCGroups2ForCurrentProcess",
+    "newCGroups2FromMountInfo",
+    "(*CGroups2).CPUQuota",
+    # cgroups v2 filesystem files
+    "cpu.max",
+    "memory.max",
+    "cgroup.controllers",
+    # cgroups2.go source file reference
+    "cgroups2.go",
+    # containerd cgroups v2
+    "containerd/cgroups/v2",
+    "containerd/cgroups/v3",
+)
+
+GO_V2_AWARE_LIBRARIES: dict[str, dict] = {
+    "go.uber.org/automaxprocs": {
+        "min_v2_version": "v1.5.0",
+        "v1_patterns_covered": ["cpu.cfs_quota_us", "cpu.cfs_period_us"],
+        "v2_indicators": ["isCGroupV2", "CGroups2", "cgroups2.go"],
+        "description": "GOMAXPROCS auto-tuning with cgroup v2 support",
+    },
+    "github.com/containerd/cgroups": {
+        "min_v2_version": "v1.0.0",
+        "v1_patterns_covered": [
+            "cpu.cfs_quota_us",
+            "cpu.cfs_period_us",
+            "memory.limit_in_bytes",
+            "cpuacct",
+        ],
+        "v2_indicators": ["cgroup.controllers", "cpu.max", "memory.max"],
+        "description": "containerd cgroups management library",
+    },
+    "github.com/opencontainers/runc/libcontainer/cgroups": {
+        "min_v2_version": "v1.1.0",
+        "v1_patterns_covered": [
+            "cpu.cfs_quota_us",
+            "cpu.cfs_period_us",
+            "memory.limit_in_bytes",
+            "cpuacct",
+        ],
+        "v2_indicators": ["cgroup.controllers", "cpu.max", "memory.max"],
+        "description": "runc cgroups management",
+    },
+    "github.com/prometheus/procfs": {
+        "min_v2_version": "v0.8.0",
+        "v1_patterns_covered": [],
+        "v2_indicators": [],
+        "description": "Prometheus proc filesystem reader (generally cgroup-neutral)",
+    },
+}
+
+_GO_BUILD_DEP_RE = re.compile(r"dep\t([\w./\-]+)\t(v[\d.]+)")
+
+
+def semver_gte(version_a: str, version_b: str) -> bool:
+    """Check if version_a >= version_b (simple semver, handles v-prefix)."""
+
+    def _parse(v: str) -> tuple[int, ...]:
+        v = v.lstrip("v")
+        parts = v.split(".")
+        return tuple(int(p) for p in parts[:3])
+
+    try:
+        return _parse(version_a) >= _parse(version_b)
+    except (ValueError, IndexError):
+        return False
+
+
+def _find_v2_awareness_indicators(strings_output: str) -> list[str]:
+    """Return V2_AWARENESS_INDICATORS found in *strings_output*."""
+    found: list[str] = []
+    for indicator in V2_AWARENESS_INDICATORS:
+        if indicator in strings_output:
+            found.append(indicator)
+    return found
+
+
+def _extract_go_dep_versions(strings_output: str) -> dict[str, str]:
+    """Extract Go module dependency versions from build info in strings output.
+
+    Go 1.18+ embeds build info with lines like:
+        dep\tgo.uber.org/automaxprocs\tv1.5.1\th1:...
+
+    Returns:
+        Dict mapping module path to version string.
+    """
+    versions: dict[str, str] = {}
+    for match in _GO_BUILD_DEP_RE.finditer(strings_output):
+        mod_path, version = match.group(1), match.group(2)
+        if mod_path not in versions:
+            versions[mod_path] = version
+    return versions
+
+
+def _is_go_binary(strings_output: str) -> bool:
+    """Heuristic check whether the strings output comes from a Go binary."""
+    return "go1." in strings_output or "\npath\t" in strings_output or "runtime.goexit" in strings_output
+
+
+def determine_v2_compliance(
+    v1_patterns_found: list[str],
+    go_libs_detected: list[str],
+    v2_indicators_found: list[str],
+    lib_versions: dict[str, str],
+) -> tuple[str, str]:
+    """Determine cgroups v2 compliance for a Go binary.
+
+    Returns:
+        Tuple of (compliance_status, compliance_note):
+        - compliance_status: one of "v2_compliant", "v2_likely_compliant",
+          "v2_unaware", "needs_review"
+        - compliance_note: human-readable explanation of the determination
+    """
+    uncovered_patterns = set(v1_patterns_found)
+    notes: list[str] = []
+    v2_indicators_set = set(v2_indicators_found)
+
+    for lib_name, lib_info in GO_V2_AWARE_LIBRARIES.items():
+        if lib_name not in go_libs_detected:
+            continue
+        detected_version = lib_versions.get(lib_name)
+        if detected_version and semver_gte(detected_version, lib_info["min_v2_version"]):
+            lib_v2_indicators = set(lib_info["v2_indicators"])
+            if not lib_v2_indicators or lib_v2_indicators.intersection(v2_indicators_set):
+                covered = set(lib_info["v1_patterns_covered"])
+                newly_covered = covered.intersection(uncovered_patterns)
+                uncovered_patterns -= covered
+                if newly_covered:
+                    short_name = lib_name.rsplit("/", 1)[-1]
+                    indicators_str = (
+                        "+".join(ind for ind in lib_info["v2_indicators"] if ind in v2_indicators_set) or "neutral"
+                    )
+                    covered_str = "+".join(sorted(newly_covered))
+                    notes.append(
+                        f"{short_name} {detected_version} (>={lib_info['min_v2_version']}): "
+                        f"{indicators_str} detected, covers {covered_str}"
+                    )
+
+    note_str = "; ".join(notes)
+
+    if not uncovered_patterns:
+        return "v2_compliant", note_str
+    elif v2_indicators_found:
+        return "v2_likely_compliant", note_str
+    elif not v2_indicators_found and not go_libs_detected:
+        return "v2_unaware", ""
+    else:
+        return "needs_review", note_str
+
+
+def detect_go_v2_compliance(
+    strings_output: str,
+    v1_patterns_found: list[str],
+    go_cgroup_libs: list[str],
+    debug: bool = False,
+) -> tuple[str, str, dict[str, str]]:
+    """Detect cgroups v2 compliance for a Go binary.
+
+    Runs all v2 awareness checks against the already-captured strings output
+    (no additional `strings` invocation).
+
+    Args:
+        strings_output: Full output from `strings` on the binary.
+        v1_patterns_found: cgroup v1 patterns already detected.
+        go_cgroup_libs: Go cgroup library paths already detected.
+        debug: Enable debug output.
+
+    Returns:
+        Tuple of (compliance_status, compliance_note, lib_versions):
+        - compliance_status: "v2_compliant", "v2_likely_compliant",
+          "v2_unaware", or "needs_review"
+        - compliance_note: human-readable explanation
+        - lib_versions: dict of detected Go module versions
+    """
+    v2_indicators = _find_v2_awareness_indicators(strings_output)
+    lib_versions = _extract_go_dep_versions(strings_output)
+
+    if debug:
+        if v2_indicators:
+            print(f"      [DEBUG]   v2 awareness indicators: {', '.join(v2_indicators)}")
+        if lib_versions:
+            ver_strs = [f"{k} {v}" for k, v in lib_versions.items()]
+            print(f"      [DEBUG]   Go dep versions: {', '.join(ver_strs)}")
+
+    logger.debug("  v2 awareness indicators: %s", v2_indicators)
+    logger.debug("  Go dep versions: %s", lib_versions)
+
+    status, note = determine_v2_compliance(
+        v1_patterns_found=v1_patterns_found,
+        go_libs_detected=go_cgroup_libs,
+        v2_indicators_found=v2_indicators,
+        lib_versions=lib_versions,
+    )
+
+    logger.debug("  v2 compliance: %s — %s", status, note)
+    if debug:
+        print(f"      [DEBUG]   v2 compliance: {status} — {note}")
+
+    return status, note, lib_versions
+
+
+# ---------------------------------------------------------------------------
 # Patterns for detecting sourced/executed scripts in shell scripts
 # ---------------------------------------------------------------------------
 _SOURCE_PATTERN = re.compile(
@@ -407,7 +617,7 @@ def scan_binary_strings(
     extract_path: Path,
     binary_refs: list[str],
     debug: bool = False,
-) -> tuple[list, bool, list[str]]:
+) -> tuple[list, bool, list[str], str, str, dict[str, str]]:
     """Scan binary files via `strings` for cgroup v1 references.
 
     For each binary reference:
@@ -417,6 +627,7 @@ def scan_binary_strings(
     4. Check the output for Go cgroup library imports
     5. Check the output for cgroup v1 patterns
     6. Check for cgroup v2 patterns (v2-awareness)
+    7. For Go binaries with v1 patterns: detect v2 compliance
 
     Args:
         extract_path: Path to the extracted container rootfs.
@@ -424,10 +635,15 @@ def scan_binary_strings(
         debug: Enable debug output.
 
     Returns:
-        Tuple of (matches, v2_aware, go_cgroup_libs):
+        Tuple of (matches, v2_aware, go_cgroup_libs, compliance_status,
+        compliance_note, lib_versions):
         - matches: list of DeepScanMatch objects with confidence="low"
         - v2_aware: True if any binary contains both v1 and v2 patterns
         - go_cgroup_libs: list of detected Go cgroup package paths
+        - compliance_status: "v2_compliant", "v2_likely_compliant",
+          "v2_unaware", "needs_review", or "" if not a Go binary
+        - compliance_note: human-readable explanation of compliance
+        - lib_versions: dict of Go module versions detected
     """
     from .image_analyzer import DeepScanMatch
 
@@ -435,6 +651,9 @@ def scan_binary_strings(
     v2_aware = False
     scanned_binaries: set[str] = set()
     all_go_deps: list[str] = []
+    compliance_status = ""
+    compliance_note = ""
+    all_lib_versions: dict[str, str] = {}
 
     for binary_ref in binary_refs:
         resolved = _resolve_script_in_rootfs(binary_ref, extract_path)
@@ -499,12 +718,34 @@ def scan_binary_strings(
                 logger.debug("  Also found %d cgroup v2 patterns — v2-aware", len(v2_patterns))
                 if debug:
                     print(f"      [DEBUG]   Also found {len(v2_patterns)} cgroup v2 patterns → v2-aware")
+
+            if _is_go_binary(strings_output) and go_deps:
+                status, note, lib_vers = detect_go_v2_compliance(
+                    strings_output=strings_output,
+                    v1_patterns_found=v1_patterns,
+                    go_cgroup_libs=go_deps,
+                    debug=debug,
+                )
+                all_lib_versions.update(lib_vers)
+                if not compliance_status or _compliance_priority(status) > _compliance_priority(compliance_status):
+                    compliance_status = status
+                    compliance_note = note
         else:
             logger.debug("  No cgroup v1 patterns found in %s", binary_ref)
             if debug:
                 print(f"      [DEBUG]   No cgroup v1 patterns found in {binary_ref}")
 
-    return matches, v2_aware, all_go_deps
+    return matches, v2_aware, all_go_deps, compliance_status, compliance_note, all_lib_versions
+
+
+def _compliance_priority(status: str) -> int:
+    """Return a priority value for compliance statuses (higher = more compliant)."""
+    return {
+        "v2_compliant": 4,
+        "v2_likely_compliant": 3,
+        "needs_review": 2,
+        "v2_unaware": 1,
+    }.get(status, 0)
 
 
 def _extract_sourced_paths(content: str) -> list[str]:
@@ -687,7 +928,7 @@ def run_deep_scan(
     entrypoint: list[str] | None = None,
     cmd: list[str] | None = None,
     debug: bool = False,
-) -> tuple[list, bool, list[str]]:
+) -> tuple[list, bool, list[str], str, str, dict[str, str]]:
     """Run all deep-scan heuristics on an extracted container rootfs.
 
     Args:
@@ -698,10 +939,14 @@ def run_deep_scan(
         debug: Enable debug output.
 
     Returns:
-        Tuple of (matches, v2_aware, go_cgroup_libs):
+        Tuple of (matches, v2_aware, go_cgroup_libs, compliance_status,
+        compliance_note, lib_versions):
         - matches: list of DeepScanMatch objects
         - v2_aware: True if any scanned source has both v1 and v2 patterns
         - go_cgroup_libs: list of detected Go cgroup package paths
+        - compliance_status: Go v2 compliance determination or ""
+        - compliance_note: human-readable compliance explanation
+        - lib_versions: dict of Go module versions detected
     """
     logger.debug("Deep scan enabled for %s", image_name)
     logger.debug("Extract path: %s", extract_path)
@@ -718,6 +963,9 @@ def run_deep_scan(
     all_matches: list = []
     v2_aware = False
     all_go_libs: list[str] = []
+    compliance_status = ""
+    compliance_note = ""
+    all_lib_versions: dict[str, str] = {}
 
     combined: list[str] = []
     if entrypoint:
@@ -763,7 +1011,7 @@ def run_deep_scan(
         logger.debug("Binary refs to scan with strings: %s", binary_refs)
         if debug:
             print(f"      [DEBUG] Binary refs to scan with strings: {binary_refs}")
-        binary_matches, binary_v2_aware, go_libs = scan_binary_strings(
+        binary_matches, binary_v2_aware, go_libs, comp_status, comp_note, lib_vers = scan_binary_strings(
             extract_path=extract_path,
             binary_refs=binary_refs,
             debug=debug,
@@ -772,5 +1020,8 @@ def run_deep_scan(
         if binary_v2_aware:
             v2_aware = True
         all_go_libs.extend(lib for lib in go_libs if lib not in all_go_libs)
+        compliance_status = comp_status
+        compliance_note = comp_note
+        all_lib_versions.update(lib_vers)
 
-    return all_matches, v2_aware, all_go_libs
+    return all_matches, v2_aware, all_go_libs, compliance_status, compliance_note, all_lib_versions

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -54,6 +54,9 @@ class ImageAnalysisResult:
     deep_scan_matches: list[DeepScanMatch] = field(default_factory=list)
     deep_scan_v2_aware_flag: bool = False
     deep_scan_go_cgroup_libs_list: list[str] = field(default_factory=list)
+    deep_scan_compliance_status: str = ""
+    deep_scan_compliance_note_text: str = ""
+    deep_scan_lib_versions: dict[str, str] = field(default_factory=dict)
     error: str | None = None
 
     @property
@@ -136,21 +139,6 @@ class ImageAnalysisResult:
         return "true" if self.deep_scan_matches else "false"
 
     @property
-    def deep_scan_confidence(self) -> str:
-        """Return the highest confidence level among all matches.
-
-        Priority: high > medium > low. Empty string if no matches or not scanned.
-        """
-        if not self.deep_scan_matches:
-            return ""
-        levels = {m.confidence for m in self.deep_scan_matches}
-        if "high" in levels:
-            return "high"
-        if "medium" in levels:
-            return "medium"
-        return "low"
-
-    @property
     def deep_scan_sources(self) -> str:
         """Return pipe-separated unique source files where matches were found."""
         if not self.deep_scan_matches:
@@ -167,24 +155,63 @@ class ImageAnalysisResult:
         return "|".join(patterns)
 
     @property
-    def deep_scan_v2_aware(self) -> str:
-        """Return 'true' if any scanned source contains both v1 and v2 patterns.
+    def deep_scan_confidence(self) -> str:
+        """Return the highest confidence level among all matches.
 
+        Priority: high > medium > low. Empty string if no matches or not scanned.
+        When Go v2 compliance is "v2_compliant", binary matches are upgraded
+        to "high" confidence (we're confident the binary handles v2).
+        """
+        if not self.deep_scan_matches:
+            return ""
+        levels = {m.confidence for m in self.deep_scan_matches}
+        if self.deep_scan_compliance_status == "v2_compliant" and levels == {"low"}:
+            return "high"
+        if "high" in levels:
+            return "high"
+        if "medium" in levels:
+            return "medium"
+        return "low"
+
+    @property
+    def deep_scan_v2_aware(self) -> str:
+        """Return Go v2 compliance status when available, else boolean fallback.
+
+        Values: "v2_compliant", "v2_likely_compliant", "needs_review",
+        "v2_unaware", or legacy "true"/"false".
         Empty string if no deep scan was performed or no v1 matches found.
         """
         if not self.deep_scan_matches:
             return ""
+        if self.deep_scan_compliance_status:
+            return self.deep_scan_compliance_status
         return "true" if self.deep_scan_v2_aware_flag else "false"
 
     @property
     def deep_scan_go_cgroup_libs(self) -> str:
-        """Return pipe-separated Go cgroup library paths detected in binaries.
+        """Return pipe-separated Go cgroup library paths with versions.
 
+        Format: "lib_path version" when version is known, "lib_path" otherwise.
         Empty string if no deep scan was performed or no libraries detected.
         """
         if not self.deep_scan_go_cgroup_libs_list:
             return ""
-        return "|".join(self.deep_scan_go_cgroup_libs_list)
+        parts: list[str] = []
+        for lib in self.deep_scan_go_cgroup_libs_list:
+            version = self.deep_scan_lib_versions.get(lib)
+            if version:
+                parts.append(f"{lib} {version}")
+            else:
+                parts.append(lib)
+        return "|".join(parts)
+
+    @property
+    def deep_scan_compliance_note(self) -> str:
+        """Return the compliance determination note.
+
+        Empty string if no compliance check was performed.
+        """
+        return self.deep_scan_compliance_note_text
 
 
 class ImageAnalyzer:
@@ -1278,7 +1305,7 @@ class ImageAnalyzer:
                 entrypoint, cmd = self._get_image_entrypoint(podman_image, debug=debug)
                 from .deep_scan import run_deep_scan
 
-                deep_matches, v2_aware, go_libs = run_deep_scan(
+                deep_matches, v2_aware, go_libs, comp_status, comp_note, lib_vers = run_deep_scan(
                     extract_path=extract_path,
                     image_name=podman_image,
                     entrypoint=entrypoint,
@@ -1288,6 +1315,9 @@ class ImageAnalyzer:
                 result.deep_scan_matches = deep_matches
                 result.deep_scan_v2_aware_flag = v2_aware
                 result.deep_scan_go_cgroup_libs_list = go_libs
+                result.deep_scan_compliance_status = comp_status
+                result.deep_scan_compliance_note_text = comp_note
+                result.deep_scan_lib_versions = lib_vers
 
             if result.java_binaries:
                 for b in result.java_binaries:
@@ -1317,7 +1347,11 @@ class ImageAnalyzer:
                     print(f"      {compat} .NET: {b.version} at {b.path}")
 
             if self.deep_scan and result.deep_scan_matches:
-                v2_note = " (v2-aware)" if result.deep_scan_v2_aware_flag else ""
+                v2_note = ""
+                if result.deep_scan_compliance_status:
+                    v2_note = f" ({result.deep_scan_compliance_status})"
+                elif result.deep_scan_v2_aware_flag:
+                    v2_note = " (v2-aware)"
                 logger.debug(
                     "Deep-scan: %d cgroup v1 reference(s) found%s",
                     len(result.deep_scan_matches),
@@ -1331,14 +1365,19 @@ class ImageAnalyzer:
                     logger.debug("  [%s] %s: %s", src_matches[0].confidence, src, patterns_str)
                     print(f"        [{src_matches[0].confidence}] {src}: {patterns_str}")
                 if result.deep_scan_go_cgroup_libs_list:
-                    logger.debug("Go cgroup libraries: %s", ", ".join(result.deep_scan_go_cgroup_libs_list))
-                    print(f"      📦 Go cgroup libraries: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
+                    libs_display = result.deep_scan_go_cgroup_libs
+                    logger.debug("Go cgroup libraries: %s", libs_display)
+                    print(f"      📦 Go cgroup libraries: {libs_display}")
+                if result.deep_scan_compliance_note_text:
+                    logger.debug("Compliance: %s", result.deep_scan_compliance_note_text)
+                    print(f"      📋 Compliance: {result.deep_scan_compliance_note_text}")
             elif self.deep_scan:
                 logger.debug("Deep-scan: no cgroup v1 references found")
                 print("      ✓ Deep-scan: no cgroup v1 references found")
                 if result.deep_scan_go_cgroup_libs_list:
-                    logger.debug("Go cgroup libraries detected: %s", ", ".join(result.deep_scan_go_cgroup_libs_list))
-                    print(f"      📦 Go cgroup libraries detected: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
+                    libs_display = result.deep_scan_go_cgroup_libs
+                    logger.debug("Go cgroup libraries detected: %s", libs_display)
+                    print(f"      📦 Go cgroup libraries detected: {libs_display}")
 
             if not result.java_binaries and not result.node_binaries and not result.dotnet_binaries:
                 logger.debug("No Java, Node.js, or .NET binaries found")

--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -39,6 +39,7 @@ CSV_COLUMNS = [
     "deep_scan_patterns",
     "deep_scan_v2_aware",
     "deep_scan_go_cgroup_libs",
+    "deep_scan_compliance_note",
     "analysis_error",
 ]
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -33,6 +33,7 @@ ANALYSIS_KEYS = (
     "deep_scan_patterns",
     "deep_scan_v2_aware",
     "deep_scan_go_cgroup_libs",
+    "deep_scan_compliance_note",
     "analysis_error",
 )
 

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -11,17 +11,23 @@ from src.deep_scan import (
     CGROUPV2_FILE_NAMES,
     CGROUPV2_REGEX,
     GO_CGROUP_PACKAGES,
+    _extract_go_dep_versions,
     _extract_sourced_paths,
+    _find_v2_awareness_indicators,
     _is_elf_binary,
+    _is_go_binary,
     _is_shell_script,
     _resolve_script_in_rootfs,
     _run_strings,
+    detect_go_v2_compliance,
+    determine_v2_compliance,
     find_cgroupv1_patterns,
     find_cgroupv2_patterns,
     find_go_cgroup_deps,
     run_deep_scan,
     scan_binary_strings,
     scan_entrypoint_scripts,
+    semver_gte,
 )
 
 
@@ -663,7 +669,7 @@ MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 exec "$@"
 """,
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -674,7 +680,7 @@ exec "$@"
         assert v2_aware is False
 
     def test_without_entrypoint(self, tmp_path):
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=None,
@@ -695,7 +701,7 @@ else
 fi
 """,
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -706,7 +712,7 @@ fi
 
     def test_debug_does_not_crash(self, tmp_path):
         """Debug mode should not raise exceptions."""
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             debug=True,
@@ -791,7 +797,7 @@ class TestScanBinaryStrings:
                 "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
             ],
         )
-        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        matches, v2_aware, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert len(matches) > 0
         assert all(m.confidence == "low" for m in matches)
         assert all(m.source.startswith("binary:") for m in matches)
@@ -807,7 +813,7 @@ class TestScanBinaryStrings:
                 "memory.max_is_a_long_enough_string",
             ],
         )
-        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        matches, v2_aware, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert len(matches) > 0
         assert v2_aware is True
 
@@ -816,19 +822,19 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "cleanapp",
             ["just_some_random_long_string_here", "another_normal_string_data"],
         )
-        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/cleanapp"], debug=False)
+        matches, v2_aware, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/cleanapp"], debug=False)
         assert matches == []
         assert v2_aware is False
 
     def test_nonexistent_binary_skipped(self, tmp_path):
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/nonexistent"], debug=False)
+        matches, _, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/nonexistent"], debug=False)
         assert matches == []
 
     def test_shell_script_skipped(self, tmp_path):
         script = tmp_path / "usr" / "bin" / "run.sh"
         script.parent.mkdir(parents=True)
         script.write_text("#!/bin/bash\ncat /sys/fs/cgroup/memory/memory.limit_in_bytes")
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/run.sh"], debug=False)
+        matches, _, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/run.sh"], debug=False)
         assert matches == []
 
     def test_multiple_binaries(self, tmp_path):
@@ -840,7 +846,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "app2",
             ["/sys/fs/cgroup/cpu/cpu.cfs_quota_us"],
         )
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
+        matches, _, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
         assert len(matches) >= 2
         sources = {m.source for m in matches}
         assert "binary:/usr/bin/app1" in sources
@@ -851,7 +857,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False)
+        matches, _, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False)
         pattern_count = sum(1 for m in matches if m.pattern == "memory.limit_in_bytes")
         assert pattern_count == 1
 
@@ -861,7 +867,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "local" / "bin" / "cgroup-reader",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False)
+        matches, _, _, _, _, _ = scan_binary_strings(tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False)
         assert len(matches) > 0
         assert matches[0].source == "binary:/usr/local/bin/cgroup-reader"
 
@@ -892,7 +898,7 @@ class TestRunDeepScanWithBinary:
                 "/sys/fs/cgroup/cpuacct/cpuacct.usage",
             ],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="cadvisor:v0.44.0",
             entrypoint=["/usr/bin/cadvisor"],
@@ -911,7 +917,7 @@ MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 exec "$@"
 """,
         )
-        matches, _, _ = run_deep_scan(
+        matches, _, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -931,7 +937,7 @@ exec "$@"
                 "memory.max_and_some_padding",
             ],
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="monitor:latest",
             entrypoint=["/usr/bin/monitor"],
@@ -953,7 +959,7 @@ exec "$@"
             tmp_path / "usr" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/wrapper.sh"],
@@ -970,7 +976,7 @@ exec "$@"
             tmp_path / "usr" / "bin" / "nginx",
             ["welcome_to_nginx_server", "http_proxy_module_loaded"],
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="nginx:latest",
             entrypoint=["/usr/bin/nginx"],
@@ -995,7 +1001,7 @@ exec /usr/local/bin/myapp
                 "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
             ],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1018,7 +1024,7 @@ exec /usr/local/bin/myapp
             tmp_path / "usr" / "local" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1050,7 +1056,7 @@ echo hello
 exec "$@"
 """,
         )
-        matches, _, _ = run_deep_scan(
+        matches, _, _, _, _, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1151,7 +1157,7 @@ class TestScanBinaryStringsGoDeps:
                 "net/http.ListenAndServe",
             ],
         )
-        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
+        _, _, go_libs, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
         assert "github.com/prometheus/procfs" in go_libs
 
     def test_go_deps_without_v1_patterns(self, tmp_path):
@@ -1163,7 +1169,7 @@ class TestScanBinaryStringsGoDeps:
                 "just_some_normal_long_text_here",
             ],
         )
-        matches, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
+        matches, _, go_libs, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
         assert matches == []
         assert "github.com/prometheus/procfs" in go_libs
 
@@ -1177,7 +1183,7 @@ class TestScanBinaryStringsGoDeps:
                 "github.com/opencontainers/runc/libcontainer/cgroups",
             ],
         )
-        matches, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/cadvisor"], debug=False)
+        matches, _, go_libs, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/cadvisor"], debug=False)
         assert len(matches) > 0
         assert len(go_libs) >= 2
 
@@ -1190,7 +1196,7 @@ class TestScanBinaryStringsGoDeps:
                 "libc.so.6_is_a_long_string",
             ],
         )
-        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        _, _, go_libs, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert go_libs == []
 
     def test_go_deps_deduplicated_across_binaries(self, tmp_path):
@@ -1203,5 +1209,469 @@ class TestScanBinaryStringsGoDeps:
             tmp_path / "usr" / "bin" / "app2",
             ["github.com/prometheus/procfs"],
         )
-        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
+        _, _, go_libs, _, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
         assert go_libs.count("github.com/prometheus/procfs") == 1
+
+
+class TestSemverGte:
+    """Tests for semver_gte()."""
+
+    def test_equal_versions(self):
+        assert semver_gte("v1.5.0", "v1.5.0") is True
+
+    def test_greater_patch(self):
+        assert semver_gte("v1.5.1", "v1.5.0") is True
+
+    def test_greater_minor(self):
+        assert semver_gte("v1.6.0", "v1.5.0") is True
+
+    def test_greater_major(self):
+        assert semver_gte("v2.0.0", "v1.5.0") is True
+
+    def test_lesser_patch(self):
+        assert semver_gte("v1.4.9", "v1.5.0") is False
+
+    def test_lesser_minor(self):
+        assert semver_gte("v1.4.0", "v1.5.0") is False
+
+    def test_lesser_major(self):
+        assert semver_gte("v0.9.0", "v1.0.0") is False
+
+    def test_no_v_prefix(self):
+        assert semver_gte("1.5.1", "v1.5.0") is True
+
+    def test_invalid_version_returns_false(self):
+        assert semver_gte("notaversion", "v1.0.0") is False
+
+
+class TestIsGoBinary:
+    """Tests for _is_go_binary()."""
+
+    def test_go_version_string(self):
+        assert _is_go_binary("go1.21.3\nsome other stuff") is True
+
+    def test_go_module_path(self):
+        assert _is_go_binary("some stuff\npath\tgithub.com/foo/bar\n") is True
+
+    def test_runtime_goexit(self):
+        assert _is_go_binary("runtime.goexit\n") is True
+
+    def test_not_go_binary(self):
+        assert _is_go_binary("libc.so.6\nmain\n") is False
+
+
+class TestFindV2AwarenessIndicators:
+    """Tests for _find_v2_awareness_indicators()."""
+
+    def test_finds_automaxprocs_indicators(self):
+        text = "isCGroupV2\nCGroups2\ncgroups2.go\n"
+        result = _find_v2_awareness_indicators(text)
+        assert "isCGroupV2" in result
+        assert "CGroups2" in result
+        assert "cgroups2.go" in result
+
+    def test_finds_v2_filesystem_indicators(self):
+        text = "cpu.max\nmemory.max\ncgroup.controllers\n"
+        result = _find_v2_awareness_indicators(text)
+        assert "cpu.max" in result
+        assert "memory.max" in result
+        assert "cgroup.controllers" in result
+
+    def test_no_indicators(self):
+        text = "just some random text\nnothing here\n"
+        assert _find_v2_awareness_indicators(text) == []
+
+
+class TestExtractGoDepVersions:
+    """Tests for _extract_go_dep_versions()."""
+
+    def test_parses_dep_lines(self):
+        text = (
+            "path\tgithub.com/myapp\n"
+            "dep\tgo.uber.org/automaxprocs\tv1.5.1\th1:abc123\n"
+            "dep\tgithub.com/prometheus/procfs\tv0.7.3\th1:def456\n"
+        )
+        result = _extract_go_dep_versions(text)
+        assert result["go.uber.org/automaxprocs"] == "v1.5.1"
+        assert result["github.com/prometheus/procfs"] == "v0.7.3"
+
+    def test_no_deps(self):
+        text = "just some binary strings\n"
+        assert _extract_go_dep_versions(text) == {}
+
+    def test_first_version_wins(self):
+        text = "dep\tgo.uber.org/automaxprocs\tv1.5.1\th1:abc\ndep\tgo.uber.org/automaxprocs\tv1.4.0\th1:old\n"
+        result = _extract_go_dep_versions(text)
+        assert result["go.uber.org/automaxprocs"] == "v1.5.1"
+
+
+class TestDetermineV2Compliance:
+    """Tests for determine_v2_compliance()."""
+
+    def test_v2_compliant_automaxprocs(self):
+        """automaxprocs v1.5.1 with v2 indicators covers cpu.cfs_quota_us + cpu.cfs_period_us."""
+        status, note = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us", "cpu.cfs_period_us"],
+            go_libs_detected=["go.uber.org/automaxprocs"],
+            v2_indicators_found=["isCGroupV2", "CGroups2", "cgroups2.go"],
+            lib_versions={"go.uber.org/automaxprocs": "v1.5.1"},
+        )
+        assert status == "v2_compliant"
+        assert "automaxprocs" in note
+        assert "v1.5.1" in note
+
+    def test_v2_likely_compliant_old_automaxprocs(self):
+        """automaxprocs v1.4.0 (pre-v2) with v2 indicators → v2_likely_compliant."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us", "cpu.cfs_period_us"],
+            go_libs_detected=["go.uber.org/automaxprocs"],
+            v2_indicators_found=["isCGroupV2"],
+            lib_versions={"go.uber.org/automaxprocs": "v1.4.0"},
+        )
+        assert status == "v2_likely_compliant"
+
+    def test_needs_review_old_automaxprocs_no_indicators(self):
+        """automaxprocs v1.4.0 without v2 indicators → needs_review."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us", "cpu.cfs_period_us"],
+            go_libs_detected=["go.uber.org/automaxprocs"],
+            v2_indicators_found=[],
+            lib_versions={"go.uber.org/automaxprocs": "v1.4.0"},
+        )
+        assert status == "needs_review"
+
+    def test_v2_unaware_no_libs(self):
+        """No Go cgroup libraries at all → v2_unaware."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["memory.limit_in_bytes"],
+            go_libs_detected=[],
+            v2_indicators_found=[],
+            lib_versions={},
+        )
+        assert status == "v2_unaware"
+
+    def test_needs_review_unknown_lib(self):
+        """v1 patterns from a library not in GO_V2_AWARE_LIBRARIES → needs_review."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us"],
+            go_libs_detected=["github.com/unknown/cgroup-lib"],
+            v2_indicators_found=[],
+            lib_versions={},
+        )
+        assert status == "needs_review"
+
+    def test_v2_likely_compliant_with_indicators(self):
+        """v2 indicators found but uncovered patterns remain → v2_likely_compliant."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us", "memory.limit_in_bytes", "blkio.weight"],
+            go_libs_detected=["go.uber.org/automaxprocs"],
+            v2_indicators_found=["isCGroupV2", "CGroups2", "cgroups2.go"],
+            lib_versions={"go.uber.org/automaxprocs": "v1.5.1"},
+        )
+        assert status == "v2_likely_compliant"
+
+    def test_v2_compliant_containerd_cgroups(self):
+        """containerd/cgroups v1.0.0+ with v2 indicators covers v1 patterns."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us", "cpu.cfs_period_us", "memory.limit_in_bytes"],
+            go_libs_detected=["github.com/containerd/cgroups"],
+            v2_indicators_found=["cgroup.controllers", "cpu.max", "memory.max"],
+            lib_versions={"github.com/containerd/cgroups": "v1.1.0"},
+        )
+        assert status == "v2_compliant"
+
+    def test_no_version_detected_with_indicators(self):
+        """Library present, version unknown, v2 indicators found → v2_likely_compliant."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us"],
+            go_libs_detected=["go.uber.org/automaxprocs"],
+            v2_indicators_found=["isCGroupV2"],
+            lib_versions={},
+        )
+        assert status == "v2_likely_compliant"
+
+    def test_no_version_no_indicators(self):
+        """Library present, version unknown, no v2 indicators → needs_review."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us"],
+            go_libs_detected=["go.uber.org/automaxprocs"],
+            v2_indicators_found=[],
+            lib_versions={},
+        )
+        assert status == "needs_review"
+
+    def test_procfs_does_not_cover_patterns(self):
+        """procfs has empty v1_patterns_covered — should not mark patterns as covered."""
+        status, _ = determine_v2_compliance(
+            v1_patterns_found=["cpu.cfs_quota_us"],
+            go_libs_detected=["github.com/prometheus/procfs"],
+            v2_indicators_found=[],
+            lib_versions={"github.com/prometheus/procfs": "v0.9.0"},
+        )
+        assert status == "needs_review"
+
+
+class TestDetectGoV2Compliance:
+    """Tests for detect_go_v2_compliance()."""
+
+    def test_full_detection(self):
+        strings_output = (
+            "go1.21.3\n"
+            "path\tgithub.com/myapp\n"
+            "dep\tgo.uber.org/automaxprocs\tv1.5.1\th1:abc\n"
+            "dep\tgithub.com/prometheus/procfs\tv0.7.3\th1:def\n"
+            "isCGroupV2\n"
+            "CGroups2\n"
+            "cgroups2.go\n"
+            "cpu.cfs_quota_us\n"
+            "cpu.cfs_period_us\n"
+        )
+        status, note, lib_vers = detect_go_v2_compliance(
+            strings_output=strings_output,
+            v1_patterns_found=["cpu.cfs_quota_us", "cpu.cfs_period_us"],
+            go_cgroup_libs=["go.uber.org/automaxprocs", "github.com/prometheus/procfs"],
+        )
+        assert status == "v2_compliant"
+        assert "automaxprocs" in note
+        assert lib_vers["go.uber.org/automaxprocs"] == "v1.5.1"
+
+    def test_no_v2_indicators(self):
+        strings_output = "go1.21.3\ndep\tgo.uber.org/automaxprocs\tv1.5.1\th1:abc\ncpu.cfs_quota_us\n"
+        status, _, _ = detect_go_v2_compliance(
+            strings_output=strings_output,
+            v1_patterns_found=["cpu.cfs_quota_us"],
+            go_cgroup_libs=["go.uber.org/automaxprocs"],
+        )
+        assert status == "needs_review"
+
+
+class TestScanBinaryStringsGoCompliance:
+    """Integration tests for Go v2 compliance detection in scan_binary_strings."""
+
+    def _create_go_binary(self, path, embedded_strings):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = b"\x7fELF" + b"\x00" * 100
+        for s in embedded_strings:
+            content += s.encode("utf-8") + b"\x00" * 10
+        content += b"\x00" * 100
+        path.write_bytes(content)
+
+    def test_go_binary_v2_compliant(self, tmp_path):
+        """Go binary with automaxprocs v1.5.1 and v2 indicators → v2_compliant."""
+        self._create_go_binary(
+            tmp_path / "usr" / "bin" / "hermodr-proxy",
+            [
+                "go1.21.3_some_padding_text",
+                "path\tgithub.com/myapp",
+                "dep\tgo.uber.org/automaxprocs\tv1.5.1\th1:abc",
+                "dep\tgithub.com/prometheus/procfs\tv0.7.3\th1:def",
+                "go.uber.org/automaxprocs",
+                "github.com/prometheus/procfs",
+                "cpu.cfs_quota_us",
+                "cpu.cfs_period_us",
+                "isCGroupV2_padding_text",
+                "CGroups2_padding_text_here",
+                "cgroups2.go_padding_text",
+            ],
+        )
+        matches, _, _, compliance, note, lib_vers = scan_binary_strings(
+            tmp_path,
+            ["/usr/bin/hermodr-proxy"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert compliance == "v2_compliant"
+        assert "automaxprocs" in note
+        assert "v1.5.1" in note
+        assert lib_vers.get("go.uber.org/automaxprocs") == "v1.5.1"
+
+    def test_go_binary_old_automaxprocs(self, tmp_path):
+        """Go binary with automaxprocs v1.4.0 (pre-v2) with v2 indicators → v2_likely_compliant."""
+        self._create_go_binary(
+            tmp_path / "usr" / "bin" / "myapp",
+            [
+                "go1.20.0_some_padding_text",
+                "dep\tgo.uber.org/automaxprocs\tv1.4.0\th1:old",
+                "go.uber.org/automaxprocs",
+                "cpu.cfs_quota_us",
+                "cpu.cfs_period_us",
+                "isCGroupV2_padding_text",
+            ],
+        )
+        _, _, _, compliance, _, _ = scan_binary_strings(
+            tmp_path,
+            ["/usr/bin/myapp"],
+            debug=False,
+        )
+        assert compliance == "v2_likely_compliant"
+
+    def test_go_binary_no_cgroup_libs(self, tmp_path):
+        """Go binary with v1 patterns but no cgroup libs → no compliance check."""
+        self._create_go_binary(
+            tmp_path / "usr" / "bin" / "myapp",
+            [
+                "go1.20.0_some_padding_text",
+                "cpu.cfs_quota_us",
+                "runtime.goexit_padding",
+            ],
+        )
+        matches, _, go_libs, compliance, _, _ = scan_binary_strings(
+            tmp_path,
+            ["/usr/bin/myapp"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert go_libs == []
+        assert compliance == ""
+
+    def test_non_go_binary_no_compliance(self, tmp_path):
+        """Non-Go binary with v1 patterns → no compliance check."""
+        self._create_go_binary(
+            tmp_path / "usr" / "bin" / "capp",
+            [
+                "libc.so.6_padding_text",
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+            ],
+        )
+        _, _, _, compliance, _, _ = scan_binary_strings(
+            tmp_path,
+            ["/usr/bin/capp"],
+            debug=False,
+        )
+        assert compliance == ""
+
+
+class TestRunDeepScanGoCompliance:
+    """Integration tests for Go compliance in run_deep_scan."""
+
+    def _create_go_binary(self, path, embedded_strings):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = b"\x7fELF" + b"\x00" * 100
+        for s in embedded_strings:
+            content += s.encode("utf-8") + b"\x00" * 10
+        content += b"\x00" * 100
+        path.write_bytes(content)
+
+    def test_deep_scan_returns_compliance(self, tmp_path):
+        """run_deep_scan returns compliance info for Go binary."""
+        self._create_go_binary(
+            tmp_path / "usr" / "bin" / "myapp",
+            [
+                "go1.21.3_some_padding_text",
+                "dep\tgo.uber.org/automaxprocs\tv1.5.1\th1:abc",
+                "go.uber.org/automaxprocs",
+                "cpu.cfs_quota_us",
+                "cpu.cfs_period_us",
+                "isCGroupV2_padding_text",
+                "CGroups2_padding_text_here",
+                "cgroups2.go_padding_text",
+            ],
+        )
+        matches, _, _, compliance, note, _ = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=["/usr/bin/myapp"],
+            debug=False,
+        )
+        assert len(matches) > 0
+        assert compliance == "v2_compliant"
+        assert "automaxprocs" in note
+
+    def test_deep_scan_no_compliance_for_scripts(self, tmp_path):
+        """Shell scripts should not trigger compliance detection."""
+        script = tmp_path / "entrypoint.sh"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text('#!/bin/bash\nMEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)\nexec "$@"\n')
+        script.chmod(0o755)
+        _, _, _, compliance, _, _ = run_deep_scan(
+            extract_path=tmp_path,
+            image_name="test:latest",
+            entrypoint=["/entrypoint.sh"],
+            debug=False,
+        )
+        assert compliance == ""
+
+
+class TestImageAnalysisResultCompliance:
+    """Tests for compliance-aware properties on ImageAnalysisResult."""
+
+    def test_deep_scan_v2_aware_returns_compliance_status(self):
+        from src.image_analyzer import DeepScanMatch, ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_matches=[DeepScanMatch(source="binary:/app", pattern="cpu.cfs_quota_us", confidence="low")],
+            deep_scan_compliance_status="v2_compliant",
+        )
+        assert result.deep_scan_v2_aware == "v2_compliant"
+
+    def test_deep_scan_v2_aware_falls_back_to_boolean(self):
+        from src.image_analyzer import DeepScanMatch, ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_matches=[DeepScanMatch(source="/entrypoint.sh", pattern="cpu.cfs_quota_us", confidence="high")],
+            deep_scan_v2_aware_flag=True,
+        )
+        assert result.deep_scan_v2_aware == "true"
+
+    def test_deep_scan_confidence_upgraded_when_v2_compliant(self):
+        from src.image_analyzer import DeepScanMatch, ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_matches=[DeepScanMatch(source="binary:/app", pattern="cpu.cfs_quota_us", confidence="low")],
+            deep_scan_compliance_status="v2_compliant",
+        )
+        assert result.deep_scan_confidence == "high"
+
+    def test_deep_scan_confidence_not_upgraded_when_not_compliant(self):
+        from src.image_analyzer import DeepScanMatch, ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_matches=[DeepScanMatch(source="binary:/app", pattern="cpu.cfs_quota_us", confidence="low")],
+            deep_scan_compliance_status="needs_review",
+        )
+        assert result.deep_scan_confidence == "low"
+
+    def test_deep_scan_go_cgroup_libs_with_versions(self):
+        from src.image_analyzer import ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_go_cgroup_libs_list=["go.uber.org/automaxprocs", "github.com/prometheus/procfs"],
+            deep_scan_lib_versions={
+                "go.uber.org/automaxprocs": "v1.5.1",
+                "github.com/prometheus/procfs": "v0.7.3",
+            },
+        )
+        libs = result.deep_scan_go_cgroup_libs
+        assert "go.uber.org/automaxprocs v1.5.1" in libs
+        assert "github.com/prometheus/procfs v0.7.3" in libs
+
+    def test_deep_scan_go_cgroup_libs_without_versions(self):
+        from src.image_analyzer import ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_go_cgroup_libs_list=["github.com/prometheus/procfs"],
+            deep_scan_lib_versions={},
+        )
+        assert result.deep_scan_go_cgroup_libs == "github.com/prometheus/procfs"
+
+    def test_deep_scan_compliance_note_property(self):
+        from src.image_analyzer import ImageAnalysisResult
+
+        result = ImageAnalysisResult(
+            image_name="test",
+            image_id="id1",
+            deep_scan_compliance_note_text="automaxprocs v1.5.1 (>=v1.5.0): isCGroupV2+CGroups2 detected",
+        )
+        assert "automaxprocs" in result.deep_scan_compliance_note


### PR DESCRIPTION
When deep-scan finds cgroup v1 patterns in a Go binary, the tool now automatically checks whether the binary is v2-compliant by analyzing embedded build info, library versions, and v2 awareness indicators. This replaces the simple boolean deep_scan_v2_aware with a richer enum (v2_compliant, v2_likely_compliant, needs_review, v2_unaware) and adds a deep_scan_compliance_note column with human-readable details.