### PR TITLE
Add Go cgroups v2 compliance test images to Quay infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,13 @@ The setup script also builds and pushes **deep-scan test images** for heuristic 
 | `deep-scan-node-exporter` | Upstream (node-exporter v1.3.1) | Go binary, cgroup v1 positive control |
 | `deep-scan-nginx-negative` | Upstream (nginx 1.25-alpine) | Negative control — no cgroup references expected |
 | `deep-scan-redis-negative` | Upstream (redis 7-alpine) | Negative control — no cgroup references expected |
+| `deep-scan-go-v2-compliant-runtime` | Custom build | Go 1.22, no cgroup libs (expects: v2_compliant — Go runtime >= 1.19) |
+| `deep-scan-go-v2-compliant-automaxprocs` | Custom build | Go 1.22 + automaxprocs v1.6.0 (expects: v2_compliant — double confirmation) |
+| `deep-scan-go-v2-compliant-lib-only` | Custom build | Go 1.18 + automaxprocs v1.5.1 (expects: v2_compliant — library covers v2) |
+| `deep-scan-go-v2-needs-review` | Custom build | Go 1.18 + automaxprocs v1.4.0 (expects: needs_review — pre-v2 library) |
+| `deep-scan-go-v2-unaware` | Custom build | Go 1.18, no cgroup libs (expects: v2_unaware) |
+| `deep-scan-c-binary-no-go` | Custom build | C binary, no Go (expects: no Go compliance detection triggered) |
+| `deep-scan-go-v2-compliant-combo` | Custom build | Go 1.22 + automaxprocs v1.6.0 + automemlimit v0.7.0 (expects: v2_compliant — multi-library combo) |
 
 Custom images are built from Containerfiles in `manifests/quay/deep-scan-images/`.
 
@@ -1014,7 +1021,14 @@ image-cgroupsv2-inspector/
             ├── entrypoint-cgv1/
             ├── source-cgv1/
             ├── binary-cgv1/
-            └── exec-cgv1/
+            ├── exec-cgv1/
+            ├── go-v2-compliant-runtime/       # Go v2 compliance test images
+            ├── go-v2-compliant-automaxprocs/
+            ├── go-v2-compliant-lib-only/
+            ├── go-v2-needs-review/
+            ├── go-v2-unaware/
+            ├── c-binary-no-go/
+            └── go-v2-compliant-combo/
 ```
 
 ## Development

--- a/manifests/quay/deep-scan-images/c-binary-no-go/Containerfile
+++ b/manifests/quay/deep-scan-images/c-binary-no-go/Containerfile
@@ -1,0 +1,8 @@
+FROM docker.io/library/gcc:13 AS builder
+WORKDIR /src
+COPY main.c .
+RUN gcc -static -o /app main.c
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/c-binary-no-go/main.c
+++ b/manifests/quay/deep-scan-images/c-binary-no-go/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+
+volatile sig_atomic_t running = 1;
+
+void handle_signal(int sig) {
+    running = 0;
+}
+
+int main() {
+    signal(SIGTERM, handle_signal);
+    signal(SIGINT, handle_signal);
+    printf("c-binary-no-go: non-Go binary for testing\n");
+    fflush(stdout);
+    while(running) { sleep(3600); }
+    return 0;
+}

--- a/manifests/quay/deep-scan-images/go-v2-compliant-automaxprocs/Containerfile
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-automaxprocs/Containerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.22-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /app main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/go-v2-compliant-automaxprocs/go.mod
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-automaxprocs/go.mod
@@ -1,0 +1,5 @@
+module go-v2-compliant-automaxprocs
+
+go 1.22
+
+require go.uber.org/automaxprocs v1.6.0

--- a/manifests/quay/deep-scan-images/go-v2-compliant-automaxprocs/main.go
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-automaxprocs/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
+	_ "go.uber.org/automaxprocs"
+)
+
+func main() {
+	fmt.Printf("go-v2-compliant-automaxprocs: Go %s, GOMAXPROCS=%d\n", runtime.Version(), runtime.GOMAXPROCS(0))
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/manifests/quay/deep-scan-images/go-v2-compliant-combo/Containerfile
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-combo/Containerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.22-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /app main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/go-v2-compliant-combo/go.mod
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-combo/go.mod
@@ -1,0 +1,8 @@
+module go-v2-compliant-combo
+
+go 1.22
+
+require (
+	github.com/KimMachineGun/automemlimit v0.7.0
+	go.uber.org/automaxprocs v1.6.0
+)

--- a/manifests/quay/deep-scan-images/go-v2-compliant-combo/main.go
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-combo/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"runtime/debug"
+	"syscall"
+
+	_ "github.com/KimMachineGun/automemlimit"
+	_ "go.uber.org/automaxprocs"
+)
+
+func main() {
+	memlimit := debug.SetMemoryLimit(-1)
+	fmt.Printf("go-v2-compliant-combo: Go %s, GOMAXPROCS=%d, GOMEMLIMIT=%d\n",
+		runtime.Version(), runtime.GOMAXPROCS(0), memlimit)
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/manifests/quay/deep-scan-images/go-v2-compliant-lib-only/Containerfile
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-lib-only/Containerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.18-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /app main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/go-v2-compliant-lib-only/go.mod
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-lib-only/go.mod
@@ -1,0 +1,5 @@
+module go-v2-compliant-lib-only
+
+go 1.18
+
+require go.uber.org/automaxprocs v1.5.1

--- a/manifests/quay/deep-scan-images/go-v2-compliant-lib-only/main.go
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-lib-only/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
+	_ "go.uber.org/automaxprocs"
+)
+
+func main() {
+	fmt.Printf("go-v2-compliant-lib-only: Go %s, GOMAXPROCS=%d\n", runtime.Version(), runtime.GOMAXPROCS(0))
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/manifests/quay/deep-scan-images/go-v2-compliant-runtime/Containerfile
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-runtime/Containerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.22-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /app main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/go-v2-compliant-runtime/go.mod
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-runtime/go.mod
@@ -1,0 +1,3 @@
+module go-v2-compliant-runtime
+
+go 1.22

--- a/manifests/quay/deep-scan-images/go-v2-compliant-runtime/main.go
+++ b/manifests/quay/deep-scan-images/go-v2-compliant-runtime/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+)
+
+func main() {
+	fmt.Printf("go-v2-compliant-runtime: Go %s, GOMAXPROCS=%d\n", runtime.Version(), runtime.GOMAXPROCS(0))
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/manifests/quay/deep-scan-images/go-v2-needs-review/Containerfile
+++ b/manifests/quay/deep-scan-images/go-v2-needs-review/Containerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.18-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /app main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/go-v2-needs-review/go.mod
+++ b/manifests/quay/deep-scan-images/go-v2-needs-review/go.mod
@@ -1,0 +1,5 @@
+module go-v2-needs-review
+
+go 1.18
+
+require go.uber.org/automaxprocs v1.4.0

--- a/manifests/quay/deep-scan-images/go-v2-needs-review/main.go
+++ b/manifests/quay/deep-scan-images/go-v2-needs-review/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
+	_ "go.uber.org/automaxprocs"
+)
+
+func main() {
+	fmt.Printf("go-v2-needs-review: Go %s, GOMAXPROCS=%d\n", runtime.Version(), runtime.GOMAXPROCS(0))
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/manifests/quay/deep-scan-images/go-v2-unaware/Containerfile
+++ b/manifests/quay/deep-scan-images/go-v2-unaware/Containerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.18-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /app main.go
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app /usr/local/bin/app
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/manifests/quay/deep-scan-images/go-v2-unaware/go.mod
+++ b/manifests/quay/deep-scan-images/go-v2-unaware/go.mod
@@ -1,0 +1,3 @@
+module go-v2-unaware
+
+go 1.18

--- a/manifests/quay/deep-scan-images/go-v2-unaware/main.go
+++ b/manifests/quay/deep-scan-images/go-v2-unaware/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+)
+
+func main() {
+	fmt.Printf("go-v2-unaware: Go %s, GOMAXPROCS=%d\n", runtime.Version(), runtime.GOMAXPROCS(0))
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/manifests/quay/quay-setup.sh
+++ b/manifests/quay/quay-setup.sh
@@ -533,6 +533,14 @@ push_test_images() {
     podman rmi "deep-scan-c-binary-no-go:latest" 2>/dev/null || true
     echo ""
 
+    # --- Case 7: Go>=1.19 + automaxprocs + automemlimit → v2_compliant (combo) ---
+    info "=== deep-scan-go-v2-compliant-combo (Go 1.22 + automaxprocs v1.6.0 + automemlimit v0.7.0) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/go-v2-compliant-combo" \
+        "Containerfile" "deep-scan-go-v2-compliant-combo" "latest" || true
+    add_tag "deep-scan-go-v2-compliant-combo" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-go-v2-compliant-combo:latest" 2>/dev/null || true
+    echo ""
+
     # --- deep-scan-cadvisor (upstream, cgroup v1 positive) ---
     info "=== deep-scan-cadvisor (cAdvisor v0.44.0, cgroup v1 positive) ==="
     pull_tag_push "gcr.io/cadvisor/cadvisor:v0.44.0" \

--- a/manifests/quay/quay-setup.sh
+++ b/manifests/quay/quay-setup.sh
@@ -476,6 +476,63 @@ push_test_images() {
     podman rmi "deep-scan-exec-cgv1:latest" 2>/dev/null || true
     echo ""
 
+    # ================================================================
+    # Go cgroups v2 compliance test images
+    # ================================================================
+    echo ""
+    info "================================================================"
+    info "  Go cgroups v2 compliance test images"
+    info "================================================================"
+    echo ""
+
+    # --- Case 1: Go>=1.19, no cgroup libs → v2_compliant (runtime) ---
+    info "=== deep-scan-go-v2-compliant-runtime (Go 1.22, no cgroup libs) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/go-v2-compliant-runtime" \
+        "Containerfile" "deep-scan-go-v2-compliant-runtime" "latest" || true
+    add_tag "deep-scan-go-v2-compliant-runtime" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-go-v2-compliant-runtime:latest" 2>/dev/null || true
+    echo ""
+
+    # --- Case 2: Go>=1.19 + automaxprocs>=1.5.0 → v2_compliant (double) ---
+    info "=== deep-scan-go-v2-compliant-automaxprocs (Go 1.22 + automaxprocs v1.6.0) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/go-v2-compliant-automaxprocs" \
+        "Containerfile" "deep-scan-go-v2-compliant-automaxprocs" "latest" || true
+    add_tag "deep-scan-go-v2-compliant-automaxprocs" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-go-v2-compliant-automaxprocs:latest" 2>/dev/null || true
+    echo ""
+
+    # --- Case 3: Go<1.19 + automaxprocs>=1.5.0 → v2_compliant (lib) ---
+    info "=== deep-scan-go-v2-compliant-lib-only (Go 1.18 + automaxprocs v1.5.1) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/go-v2-compliant-lib-only" \
+        "Containerfile" "deep-scan-go-v2-compliant-lib-only" "latest" || true
+    add_tag "deep-scan-go-v2-compliant-lib-only" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-go-v2-compliant-lib-only:latest" 2>/dev/null || true
+    echo ""
+
+    # --- Case 4: Go<1.19 + automaxprocs<1.5.0 → needs_review ---
+    info "=== deep-scan-go-v2-needs-review (Go 1.18 + automaxprocs v1.4.0) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/go-v2-needs-review" \
+        "Containerfile" "deep-scan-go-v2-needs-review" "latest" || true
+    add_tag "deep-scan-go-v2-needs-review" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-go-v2-needs-review:latest" 2>/dev/null || true
+    echo ""
+
+    # --- Case 5: Go<1.19, no cgroup libs → v2_unaware ---
+    info "=== deep-scan-go-v2-unaware (Go 1.18, no cgroup libs) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/go-v2-unaware" \
+        "Containerfile" "deep-scan-go-v2-unaware" "latest" || true
+    add_tag "deep-scan-go-v2-unaware" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-go-v2-unaware:latest" 2>/dev/null || true
+    echo ""
+
+    # --- Case 6: C binary, no Go → no Go detection ---
+    info "=== deep-scan-c-binary-no-go (C binary, negative control for Go detection) ==="
+    build_and_push "${SCRIPT_DIR}/deep-scan-images/c-binary-no-go" \
+        "Containerfile" "deep-scan-c-binary-no-go" "latest" || true
+    add_tag "deep-scan-c-binary-no-go" "latest" "v1.0-${DATE_TAG}" || true
+    podman rmi "deep-scan-c-binary-no-go:latest" 2>/dev/null || true
+    echo ""
+
     # --- deep-scan-cadvisor (upstream, cgroup v1 positive) ---
     info "=== deep-scan-cadvisor (cAdvisor v0.44.0, cgroup v1 positive) ==="
     pull_tag_push "gcr.io/cadvisor/cadvisor:v0.44.0" \

--- a/manifests/quay/quay-teardown.sh
+++ b/manifests/quay/quay-teardown.sh
@@ -77,6 +77,7 @@ TEST_REPOS=(
     deep-scan-go-v2-needs-review
     deep-scan-go-v2-unaware
     deep-scan-c-binary-no-go
+    deep-scan-go-v2-compliant-combo
 )
 
 # ---------------------------------------------------------------------------

--- a/manifests/quay/quay-teardown.sh
+++ b/manifests/quay/quay-teardown.sh
@@ -70,6 +70,13 @@ TEST_REPOS=(
     deep-scan-node-exporter
     deep-scan-nginx-negative
     deep-scan-redis-negative
+    # Go cgroups v2 compliance test images
+    deep-scan-go-v2-compliant-runtime
+    deep-scan-go-v2-compliant-automaxprocs
+    deep-scan-go-v2-compliant-lib-only
+    deep-scan-go-v2-needs-review
+    deep-scan-go-v2-unaware
+    deep-scan-c-binary-no-go
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Introduce 6 new deep-scan test images covering the full cgroups v2 detection matrix for Go binaries (go version / go version -m):
- go-v2-compliant-runtime: Go 1.22, no cgroup libs (native runtime)
- go-v2-compliant-automaxprocs: Go 1.22 + automaxprocs v1.6.0
- go-v2-compliant-lib-only: Go 1.18 + automaxprocs v1.5.1
- go-v2-needs-review: Go 1.18 + automaxprocs v1.4.0
- go-v2-unaware: Go 1.18, no cgroup libs
- c-binary-no-go: C binary, negative control for Go detection Update quay-setup.sh and quay-teardown.sh to build/push/manage them.