### PR TITLE
Add deterministic Go binary cgroups v2 scanning

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,8 +3,9 @@
 FROM registry.access.redhat.com/ubi9/python-312
 
 USER root
-# Install system dependencies: podman (image pull/inspect), acl (extended ACLs for rootfs)
-RUN dnf install -y podman acl && dnf clean all
+# Install system dependencies: podman (image pull/inspect), acl (extended ACLs for rootfs),
+# golang (deterministic Go binary scanning via `go version`)
+RUN dnf install -y podman acl golang && dnf clean all
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ pip install -r requirements.txt
 
 ## Container
 
-You can build and run the tool as a container (UBI 9, Python 3.12). The image uses the main script as the entrypoint.
+You can build and run the tool as a container (UBI 9, Python 3.12). The image includes `podman`, `acl`, and `golang`, so Go binary scanning is enabled by default. The image uses the main script as the entrypoint.
 
 **Build:**
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This tool connects to an OpenShift cluster or a Quay registry, collects informat
 - 🔐 Store credentials in `.env` file for reuse
 - 📁 Create rootfs directory with proper extended ACLs
 - ✅ System checks: verify podman installation and disk space (min 20GB)
+- 🐹 Deterministic Go binary scanning — detects Go binaries via `go version` and checks cgroups v2 compatibility using a version and module matrix (`--disable-go` to opt out)
 - 🔍 Deep-scan heuristic analysis for cgroup v1 references in entrypoint scripts and binaries (`--deep-scan`)
 
 ## ⚠️ Disclaimer
@@ -141,6 +142,20 @@ This tool connects to an OpenShift cluster or a Quay registry, collects informat
   # Gentoo
   sudo emerge sys-apps/acl
   ```
+- **Go** (optional) - For deterministic Go binary scanning. When the `go` command is found in `PATH`, the tool uses `go version` and `go version -m` to extract precise version and module information from Go binaries. Without it, Go binaries are not analyzed (the `go_*` CSV columns remain empty). Use `--disable-go` to explicitly skip Go scanning even when `go` is available.
+  ```bash
+  # Fedora/RHEL/CentOS
+  sudo dnf install golang
+  
+  # Ubuntu/Debian
+  sudo apt install golang-go
+  
+  # Gentoo
+  sudo emerge dev-lang/go
+  
+  # macOS (via Homebrew)
+  brew install go
+  ```
 
 ### Cluster Requirements
 
@@ -240,7 +255,7 @@ The container runs as root. For image pulls and analysis, podman runs inside the
 # Specify rootfs path for image extraction
 ./image-cgroupsv2-inspector --rootfs-path /tmp/images
 
-# Analyze images for Java/NodeJS/.NET cgroup v2 compatibility
+# Analyze images for Java/NodeJS/.NET/Go cgroup v2 compatibility
 ./image-cgroupsv2-inspector --rootfs-path /tmp/images --analyze
 
 # Inspect only a specific namespace
@@ -467,7 +482,8 @@ A JSON state file is written automatically during every `--analyze` run, trackin
 |--------|-------------|
 | `--rootfs-path` | Path where rootfs directory will be created for image extraction |
 | `--output-dir` | Directory to save CSV output (default: `output`) |
-| `--analyze` | Analyze images for Java/NodeJS/.NET binaries (requires `--rootfs-path`) |
+| `--analyze` | Analyze images for Java/NodeJS/.NET/Go binaries (requires `--rootfs-path`) |
+| `--disable-go` | Disable Go binary scanning even when the `go` command is available on the host. By default, if `go` is found in `PATH`, Go scanning is enabled automatically |
 | `--deep-scan` | Enable heuristic deep-scan for cgroup v1 references in entrypoint scripts and binaries. Requires `--analyze`. Detects images that may not work on cgroup v2 systems even without Java/Node.js/.NET runtimes. Results appear in `deep_scan_*` CSV columns |
 | `--pull-secret` | Path to pull-secret file for image authentication (default: `.pull-secret`) |
 | `--verify-ssl` | Verify SSL certificates (default: False) |
@@ -537,13 +553,18 @@ When using the `--analyze` flag, the tool:
 4. Searches for Java, Node.js, and .NET binaries
 5. Executes `-version` / `--version` to determine the exact version
 6. Checks if the version is compatible with cgroup v2
-7. **Deep-scan** (when `--deep-scan` is also enabled):
+7. **Go scan** (when `go` is available on the host and `--disable-go` is not set):
+   - Resolves ENTRYPOINT and CMD from image metadata via `podman inspect`
+   - Runs `go version` on each candidate binary to identify Go executables
+   - Runs `go version -m` to extract module dependencies
+   - Applies a deterministic compatibility matrix based on Go version and cgroup-aware modules
+8. **Deep-scan** (when `--deep-scan` is also enabled):
    - Extracts ENTRYPOINT and CMD from image metadata via `podman inspect`
    - Scans entrypoint shell scripts for cgroup v1 path references (high confidence)
    - Follows `source`/`.`/`exec` chains to scan referenced scripts (medium confidence)
    - Runs `strings` on compiled binaries (Go, C, etc.) in the entrypoint (low confidence)
    - Detects v2-aware images that handle both cgroup v1 and v2
-8. Cleans up the image and filesystem after each analysis
+9. Cleans up the image and filesystem after each analysis
 
 ### Internal Registry Support
 
@@ -588,6 +609,28 @@ oc apply -f manifests/cluster/registry-default-route.yaml
 | Node.js | 20.3.0+ |
 | .NET | 5.0+ |
 
+### Go cgroups v2 Compatibility Matrix
+
+Go binary scanning uses a deterministic approach based on the Go runtime version and the presence of specific cgroup-aware modules:
+
+| Go Version | Modules | Result | Reason |
+|------------|---------|--------|--------|
+| >= 1.19 | (any) | **Compatible** | Go runtime natively supports cgroups v2 since 1.19 |
+| < 1.19 | v2-aware module at sufficient version | **Compatible** | Module provides cgroups v2 support |
+| < 1.19 | v2-aware module below minimum version | **Needs Review** | Module present but too old for v2 |
+| < 1.19 | No v2-aware modules | **Not Compatible** | No cgroups v2 support detected |
+
+**v2-aware modules and minimum versions:**
+
+| Module | Minimum Version |
+|--------|----------------|
+| `go.uber.org/automaxprocs` | v1.5.0 |
+| `github.com/KimMachineGun/automemlimit` | v0.1.0 |
+| `github.com/containerd/cgroups` | v1.0.0 |
+| `github.com/opencontainers/runc/libcontainer/cgroups` | v1.1.0 |
+
+The `go_modules` CSV column only includes cgroup-relevant modules (those listed above), not all dependencies.
+
 ### Deep Scan — Heuristic cgroup v1 Detection
 
 The `--deep-scan` flag enables heuristic analysis to detect cgroup v1 references beyond Java, Node.js, and .NET version checks. This catches images with shell scripts or compiled binaries that directly read cgroup v1 files (e.g., `/sys/fs/cgroup/memory/memory.limit_in_bytes`), which will fail on cgroup v2 systems like OpenShift 4.x with RHEL 9+ nodes.
@@ -625,7 +668,6 @@ When the deep-scan finds cgroup v1 patterns in a file that **also** contains cgr
 | `false` | (empty) | No cgroup v1 references found — image is fine |
 | `true` | `true` | v1 references found but image handles both v1 and v2 — likely safe |
 | `true` | `false` | v1 references found with no v2 fallback — **investigate and remediate** |
-| `false` | (empty) | No direct v1 patterns but binary uses Go cgroup libraries — investigate |
 
 #### Source Chain Following
 
@@ -639,19 +681,6 @@ source "${SCRIPT_DIR}/cgroup-helpers.sh"
 Shell variable paths like `${SCRIPT_DIR}/file.sh` are resolved by extracting the filename and looking for it relative to the sourcing script's directory.
 
 Limits: maximum source-chain depth of 5, maximum script size of 1 MB, symlinks that escape the rootfs are blocked.
-
-#### Go Cgroup Library Detection
-
-Go binaries compiled with static linking embed the full import paths of all dependencies. The deep-scan checks for known Go packages that interact with cgroups:
-
-- `github.com/opencontainers/runc/libcontainer/cgroups` — low-level cgroup management
-- `github.com/containerd/cgroups` — containerd cgroup library
-- `github.com/prometheus/procfs` — Prometheus metrics from procfs/cgroupfs
-- `github.com/google/cadvisor/container` — cAdvisor container stats
-- `go.uber.org/automaxprocs` — auto-tuning GOMAXPROCS from cgroup CPU limits
-- `github.com/KimMachineGun/automemlimit` — auto-tuning memory limits from cgroups
-
-These are reported in the `deep_scan_go_cgroup_libs` CSV column as an informational signal. Finding a library does **not** set `deep_scan_match=true` — the library might be used in v2-compatible mode. The column helps operators identify binaries that likely interact with cgroups even when no direct v1 path patterns were found.
 
 #### Deep Scan Example
 
@@ -669,6 +698,10 @@ These are reported in the `deep_scan_go_cgroup_libs` CSV column as an informatio
 #      Java found in: 0 containers
 #      Node.js found in: 0 containers
 #      .NET found in: 0 containers
+#      Go found in: 5 containers
+#        ✓ cgroup v2 compatible: 3
+#        ✗ cgroup v2 incompatible: 1
+#        ⚠ cgroup v2 needs review: 1
 #      Deep-scan matches: 3 images with cgroup v1 references
 #        ⚠ high confidence: 1
 #        ⚠ low confidence: 2
@@ -680,7 +713,7 @@ These are reported in the `deep_scan_go_cgroup_libs` CSV column as an informatio
 ### Analysis Example
 
 ```bash
-# Basic analysis (Java, Node.js, .NET version checks)
+# Basic analysis (Java, Node.js, .NET, Go version checks)
 ./image-cgroupsv2-inspector --rootfs-path /tmp/analysis --analyze
 
 # Full analysis with deep-scan heuristics
@@ -698,6 +731,11 @@ These are reported in the `deep_scan_go_cgroup_libs` CSV column as an informatio
 #      .NET found in: 8 containers
 #        ✓ cgroup v2 compatible: 6
 #        ✗ cgroup v2 incompatible: 2
+#      Go found in: 15 containers
+#        ✓ cgroup v2 compatible: 10
+#        ✗ cgroup v2 incompatible: 2
+#        ⚠ cgroup v2 needs review: 1
+#        ? cgroup v2 unknown: 2
 #      Deep-scan matches: 5 images with cgroup v1 references
 #        ⚠ high confidence: 1
 #        ⚠ medium confidence: 1
@@ -733,12 +771,15 @@ The tool generates a CSV file in the `output` directory (or the path specified b
 | `dotnet_binary` | Path to .NET binary found (or "None") |
 | `dotnet_version` | .NET version detected |
 | `dotnet_cgroup_v2_compatible` | "Yes", "No", "Unknown", or "N/A" |
+| `go_binary` | Paths to Go binaries found (or "None") |
+| `go_version` | Go version(s) detected (e.g., "go1.22.5") |
+| `go_cgroup_v2_compatible` | "Yes", "No", "Needs Review", or "None" |
+| `go_modules` | Pipe-separated cgroup-relevant Go modules with versions (e.g., `go.uber.org/automaxprocs@v1.6.0`). Only v2-aware modules are listed |
 | `deep_scan_match` | `"true"` if cgroup v1 patterns found, `"false"` if scanned with no matches, empty if not scanned |
 | `deep_scan_confidence` | Highest confidence level: `"high"`, `"medium"`, or `"low"` (empty if no match) |
 | `deep_scan_sources` | Pipe-separated file paths where matches were found (e.g., `/entrypoint.sh\|/opt/helpers.sh` or `binary:/usr/bin/cadvisor`) |
 | `deep_scan_patterns` | Pipe-separated cgroup v1 patterns matched (e.g., `memory.limit_in_bytes\|cpu.cfs_quota_us`) |
 | `deep_scan_v2_aware` | `"true"` if matched files also contain cgroup v2 patterns, `"false"` if v1-only, empty if no match |
-| `deep_scan_go_cgroup_libs` | Pipe-separated Go package paths that interact with cgroups (e.g., `github.com/prometheus/procfs\|github.com/containerd/cgroups`). Informational — these libraries may use v1 or v2 |
 | `analysis_error` | Error message if analysis failed |
 
 ### Identifying Incompatible Images
@@ -748,12 +789,19 @@ The fields that indicate cgroups v2 incompatibility are:
 - **`java_cgroup_v2_compatible`**: If set to **"No"**, the Java runtime in the image is NOT compatible with cgroup v2
 - **`node_cgroup_v2_compatible`**: If set to **"No"**, the Node.js runtime in the image is NOT compatible with cgroup v2
 - **`dotnet_cgroup_v2_compatible`**: If set to **"No"**, the .NET runtime in the image is NOT compatible with cgroup v2
+- **`go_cgroup_v2_compatible`**: If set to **"No"**, the Go binary in the image is NOT compatible with cgroup v2. If **"Needs Review"**, the binary has a v2-aware module but at a version below the minimum threshold
 
-Possible values for these fields:
+Possible values for Java/Node.js/.NET fields:
 - `Yes` - The runtime is compatible with cgroup v2
 - `No` - The runtime is **NOT** compatible with cgroup v2 and requires an upgrade
 - `Unknown` - The runtime was found but its version could not be determined (e.g. the binary failed to execute inside the container)
 - `N/A` - The runtime was not found in the image
+
+Possible values for `go_cgroup_v2_compatible`:
+- `Yes` - The Go binary is compatible with cgroup v2 (Go >= 1.19, or older Go with a v2-aware module at sufficient version)
+- `No` - The Go binary is **NOT** compatible with cgroup v2 (Go < 1.19 with no v2-aware modules)
+- `Needs Review` - The Go binary has a v2-aware module but the module version is below the minimum required for v2 support
+- `None` - No Go binary was found in the image (or Go scanning was disabled)
 
 #### Deep Scan Fields
 
@@ -995,13 +1043,15 @@ image-cgroupsv2-inspector/
 │   ├── analysis_orchestrator.py # Source-agnostic analysis orchestration (NEW in v2.0)
 │   ├── auth_utils.py           # Registry auth.json generation (NEW in v2.0)
 │   ├── image_analyzer.py       # Image analysis for cgroups v2
-│   ├── deep_scan.py            # Deep-scan heuristic cgroup v1 detection (NEW)
+│   ├── go_scan.py              # Deterministic Go binary cgroups v2 scanning (NEW)
+│   ├── deep_scan.py            # Deep-scan heuristic cgroup v1 detection
 │   ├── rootfs_manager.py       # RootFS directory management
 │   └── system_checks.py        # System requirements verification
 ├── tests/
 │   ├── __init__.py
 │   ├── test_image_analyzer.py
-│   ├── test_deep_scan.py             # NEW
+│   ├── test_go_scan.py              # NEW
+│   ├── test_deep_scan.py
 │   ├── test_image_collector.py
 │   ├── test_openshift_client.py
 │   ├── test_quay_client.py           # NEW in v2.0

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -154,6 +154,15 @@ The tool will save credentials to .env file after successful connection.
     )
 
     parser.add_argument(
+        "--disable-go",
+        dest="disable_go",
+        action="store_true",
+        default=False,
+        help="Disable Go binary cgroups v2 analysis even if 'go' is available on the host. "
+        "By default, Go analysis is enabled automatically when the 'go' command is found.",
+    )
+
+    parser.add_argument(
         "--pull-secret",
         dest="pull_secret",
         type=str,
@@ -437,6 +446,21 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
         print(f"        ✗ cgroup v2 incompatible: {dotnet_incompat}")
         if dotnet_unknown > 0:
             print(f"        ? cgroup v2 unknown: {dotnet_unknown}")
+    go_found = sum(1 for img in images if img.get("go_binary", "None") != "None")
+    go_compat = sum(1 for img in images if img.get("go_cgroup_v2_compatible") == "Yes")
+    go_incompat = sum(1 for img in images if img.get("go_cgroup_v2_compatible") == "No")
+    go_unknown = sum(1 for img in images if img.get("go_cgroup_v2_compatible") == "Unknown")
+    go_needs_review = sum(1 for img in images if img.get("go_cgroup_v2_compatible") == "Needs Review")
+    print(f"      Go found in: {go_found} containers")
+    if go_found > 0:
+        print(f"        ✓ cgroup v2 compatible: {go_compat}")
+        print(f"        ✗ cgroup v2 incompatible: {go_incompat}")
+        if go_needs_review > 0:
+            print(f"        ? cgroup v2 needs review: {go_needs_review}")
+        if go_unknown > 0:
+            print(f"        ? cgroup v2 unknown: {go_unknown}")
+    logger.debug("Analysis Results: Go found=%d (compat=%d, incompat=%d, needs_review=%d, unknown=%d)",
+                 go_found, go_compat, go_incompat, go_needs_review, go_unknown)
     deep_scan_found = sum(1 for img in images if img.get("deep_scan_match") == "true")
     if deep_scan_found > 0 or any(img.get("deep_scan_match") != "" for img in images):
         print(f"      Deep-scan matches: {deep_scan_found} images with cgroup v1 references")
@@ -458,12 +482,6 @@ def _print_analysis_summary(images: list[dict], skipped_images: list[str] | None
         if v1_only > 0:
             print(f"        ✗ v1-only (likely incompatible): {v1_only}")
         logger.debug("Deep-scan: v2-aware=%d, v1-only=%d", v2_aware_count, v1_only)
-        go_libs_count = sum(
-            1 for img in images if img.get("deep_scan_go_cgroup_libs", "") != ""
-        )
-        if go_libs_count:
-            logger.debug("Go cgroup libraries detected in %d images", go_libs_count)
-            print(f"        📦 Go cgroup libraries detected: {go_libs_count} images")
     skipped_count = len(skipped_images) if skipped_images else 0
     logger.debug("Images skipped (timeout): %d", skipped_count)
     print(f"      Images skipped (timeout): {skipped_count}")
@@ -512,6 +530,21 @@ def main() -> int:
         logger.error("System checks failed")
         return 1
     logger.info("System checks passed")
+
+    import shutil as _shutil
+
+    go_scan_enabled = False
+    if args.analyze and not args.disable_go:
+        if _shutil.which("go"):
+            go_scan_enabled = True
+            logger.info("Go scan enabled ('go' found in PATH)")
+            print("✓ Go scan enabled ('go' found in PATH)")
+        else:
+            logger.info("Go scan disabled ('go' not found in PATH)")
+            print("ℹ Go scan disabled ('go' not found in PATH)")
+    elif args.analyze and args.disable_go:
+        logger.info("Go scan disabled (--disable-go specified)")
+        print("ℹ Go scan disabled (--disable-go specified)")
 
     # Load .env early so env vars are available for both modes
     from dotenv import load_dotenv
@@ -658,6 +691,7 @@ def main() -> int:
                     resume=args.resume,
                     target=registry_host,
                     deep_scan=args.deep_scan,
+                    go_scan=go_scan_enabled,
                 )
                 _, csv_path, skipped = orchestrator.analyze_images(
                     images=images,
@@ -817,6 +851,7 @@ def main() -> int:
                 resume=args.resume,
                 target=client.cluster_name,
                 deep_scan=args.deep_scan,
+                go_scan=go_scan_enabled,
             )
             _, csv_path, skipped = orchestrator.analyze_images(
                 images=image_dicts,

--- a/src/analysis_orchestrator.py
+++ b/src/analysis_orchestrator.py
@@ -59,6 +59,7 @@ class AnalysisOrchestrator:
         resume: bool = False,
         target: str = "",
         deep_scan: bool = False,
+        go_scan: bool = False,
     ) -> None:
         self.rootfs_path = rootfs_path
         self.pull_secret_path = pull_secret_path
@@ -69,6 +70,7 @@ class AnalysisOrchestrator:
         self.resume = resume
         self.target = target
         self.deep_scan = deep_scan
+        self.go_scan = go_scan
 
     def _save_csv(self, images: list[dict], filepath: str) -> None:
         """Write image records to CSV using the unified schema."""
@@ -113,6 +115,7 @@ class AnalysisOrchestrator:
             self.internal_registry_route,
             self.openshift_token,
             deep_scan=self.deep_scan,
+            go_scan=self.go_scan,
         )
 
         unique_image_names: list[str] = []
@@ -293,10 +296,13 @@ class AnalysisOrchestrator:
                 record["dotnet_binary"] = result.dotnet_found
                 record["dotnet_version"] = result.dotnet_versions
                 record["dotnet_cgroup_v2_compatible"] = result.dotnet_compatible
+                record["go_binary"] = result.go_found
+                record["go_version"] = result.go_versions
+                record["go_cgroup_v2_compatible"] = result.go_compatible
+                record["go_modules"] = result.go_modules_str
                 record["analysis_error"] = result.error or ""
                 record["deep_scan_match"] = result.deep_scan_match
                 record["deep_scan_confidence"] = result.deep_scan_confidence
                 record["deep_scan_sources"] = result.deep_scan_sources
                 record["deep_scan_patterns"] = result.deep_scan_patterns
                 record["deep_scan_v2_aware"] = result.deep_scan_v2_aware
-                record["deep_scan_go_cgroup_libs"] = result.deep_scan_go_cgroup_libs

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -165,58 +165,6 @@ def find_cgroupv2_patterns(text: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Known Go packages that interact with cgroups.
-# If these import paths appear in the `strings` output of a static Go binary,
-# the binary likely reads or manipulates cgroup files at runtime.
-# ---------------------------------------------------------------------------
-GO_CGROUP_PACKAGES = (
-    # Low-level cgroup libraries
-    "github.com/opencontainers/runc/libcontainer/cgroups",
-    "github.com/containerd/cgroups",
-    "github.com/opencontainers/cgroups",
-    # Metrics/monitoring libraries that read cgroup stats
-    "github.com/prometheus/procfs",
-    "github.com/google/cadvisor/container",
-    "github.com/google/cadvisor/cgroup",
-    # Go runtime cgroup awareness (embedded in all recent Go binaries,
-    # but these specific sub-paths indicate direct cgroup interaction)
-    "runtime/cgroup",
-    # Container runtime libraries
-    "github.com/docker/docker/daemon/stats",
-    "github.com/containers/podman",
-    # Kubernetes cgroup management
-    "k8s.io/kubernetes/pkg/kubelet/cm",
-    "k8s.io/kubernetes/pkg/kubelet/stats",
-    # Auto-tuning libraries that read cgroups for GOMAXPROCS/memory
-    "go.uber.org/automaxprocs",
-    "github.com/KimMachineGun/automemlimit",
-)
-
-# Build a regex for efficient matching of Go package paths.
-# These are always preceded by a path separator or start of line in strings output.
-_GO_PKG_STRINGS = list(GO_CGROUP_PACKAGES)
-_GO_PKG_STRINGS.sort(key=len, reverse=True)
-GO_CGROUP_REGEX = re.compile("|".join(re.escape(p) for p in _GO_PKG_STRINGS))
-
-
-def find_go_cgroup_deps(text: str) -> list[str]:
-    """Return de-duplicated Go cgroup package paths found in *text*.
-
-    Args:
-        text: Output from `strings` command on a Go binary.
-
-    Returns:
-        List of unique matched Go package paths, in order of first occurrence.
-    """
-    seen: dict[str, None] = {}
-    for match in GO_CGROUP_REGEX.finditer(text):
-        pkg = match.group(0)
-        if pkg not in seen:
-            seen[pkg] = None
-    return list(seen)
-
-
-# ---------------------------------------------------------------------------
 # Patterns for detecting sourced/executed scripts in shell scripts
 # ---------------------------------------------------------------------------
 _SOURCE_PATTERN = re.compile(
@@ -407,16 +355,15 @@ def scan_binary_strings(
     extract_path: Path,
     binary_refs: list[str],
     debug: bool = False,
-) -> tuple[list, bool, list[str]]:
+) -> tuple[list, bool]:
     """Scan binary files via `strings` for cgroup v1 references.
 
     For each binary reference:
     1. Resolve it in the extracted rootfs
     2. Verify it's an ELF binary
     3. Run `strings` on it
-    4. Check the output for Go cgroup library imports
-    5. Check the output for cgroup v1 patterns
-    6. Check for cgroup v2 patterns (v2-awareness)
+    4. Check the output for cgroup v1 patterns
+    5. Check for cgroup v2 patterns (v2-awareness)
 
     Args:
         extract_path: Path to the extracted container rootfs.
@@ -424,17 +371,15 @@ def scan_binary_strings(
         debug: Enable debug output.
 
     Returns:
-        Tuple of (matches, v2_aware, go_cgroup_libs):
+        Tuple of (matches, v2_aware):
         - matches: list of DeepScanMatch objects with confidence="low"
         - v2_aware: True if any binary contains both v1 and v2 patterns
-        - go_cgroup_libs: list of detected Go cgroup package paths
     """
     from .image_analyzer import DeepScanMatch
 
     matches: list[DeepScanMatch] = []
     v2_aware = False
     scanned_binaries: set[str] = set()
-    all_go_deps: list[str] = []
 
     for binary_ref in binary_refs:
         resolved = _resolve_script_in_rootfs(binary_ref, extract_path)
@@ -471,13 +416,6 @@ def scan_binary_strings(
         if strings_output is None:
             continue
 
-        go_deps = find_go_cgroup_deps(strings_output)
-        if go_deps:
-            all_go_deps.extend(dep for dep in go_deps if dep not in all_go_deps)
-            logger.debug("  Found %d Go cgroup libraries: %s", len(go_deps), ", ".join(go_deps))
-            if debug:
-                print(f"      [DEBUG]   Found {len(go_deps)} Go cgroup libraries: {', '.join(go_deps)}")
-
         v1_patterns = find_cgroupv1_patterns(strings_output)
         if v1_patterns:
             source = f"binary:{binary_ref}"
@@ -504,7 +442,7 @@ def scan_binary_strings(
             if debug:
                 print(f"      [DEBUG]   No cgroup v1 patterns found in {binary_ref}")
 
-    return matches, v2_aware, all_go_deps
+    return matches, v2_aware
 
 
 def _extract_sourced_paths(content: str) -> list[str]:
@@ -687,7 +625,7 @@ def run_deep_scan(
     entrypoint: list[str] | None = None,
     cmd: list[str] | None = None,
     debug: bool = False,
-) -> tuple[list, bool, list[str]]:
+) -> tuple[list, bool]:
     """Run all deep-scan heuristics on an extracted container rootfs.
 
     Args:
@@ -698,10 +636,9 @@ def run_deep_scan(
         debug: Enable debug output.
 
     Returns:
-        Tuple of (matches, v2_aware, go_cgroup_libs):
+        Tuple of (matches, v2_aware):
         - matches: list of DeepScanMatch objects
         - v2_aware: True if any scanned source has both v1 and v2 patterns
-        - go_cgroup_libs: list of detected Go cgroup package paths
     """
     logger.debug("Deep scan enabled for %s", image_name)
     logger.debug("Extract path: %s", extract_path)
@@ -717,7 +654,6 @@ def run_deep_scan(
 
     all_matches: list = []
     v2_aware = False
-    all_go_libs: list[str] = []
 
     combined: list[str] = []
     if entrypoint:
@@ -763,7 +699,7 @@ def run_deep_scan(
         logger.debug("Binary refs to scan with strings: %s", binary_refs)
         if debug:
             print(f"      [DEBUG] Binary refs to scan with strings: {binary_refs}")
-        binary_matches, binary_v2_aware, go_libs = scan_binary_strings(
+        binary_matches, binary_v2_aware = scan_binary_strings(
             extract_path=extract_path,
             binary_refs=binary_refs,
             debug=debug,
@@ -771,6 +707,5 @@ def run_deep_scan(
         all_matches.extend(binary_matches)
         if binary_v2_aware:
             v2_aware = True
-        all_go_libs.extend(lib for lib in go_libs if lib not in all_go_libs)
 
-    return all_matches, v2_aware, all_go_libs
+    return all_matches, v2_aware

--- a/src/go_scan.py
+++ b/src/go_scan.py
@@ -60,8 +60,10 @@ def parse_go_version(version_str: str) -> tuple[int | None, int | None]:
 
 def semver_gte(version_a: str, version_b: str) -> bool:
     """Check if *version_a* >= *version_b* (simple semver with v-prefix)."""
+
     def parse(v: str) -> tuple[int, ...]:
         return tuple(int(p) for p in v.lstrip("v").split(".")[:3])
+
     try:
         return parse(version_a) >= parse(version_b)
     except (ValueError, IndexError):
@@ -100,8 +102,7 @@ def check_go_compatibility(
                 )
             else:
                 return None, (
-                    f"Go {major}.{minor} < 1.19, {short_name} "
-                    f"{detected_version} < {min_version}: needs review"
+                    f"Go {major}.{minor} < 1.19, {short_name} {detected_version} < {min_version}: needs review"
                 )
 
     return False, f"Go {major}.{minor} < 1.19, no v2-aware cgroup modules detected"

--- a/src/go_scan.py
+++ b/src/go_scan.py
@@ -1,0 +1,283 @@
+"""
+Go Scan Module
+==============
+
+Deterministic Go binary cgroups v2 compatibility analysis.
+
+Detects Go binaries in container images by running ``go version`` and
+``go version -m`` from the host machine against extracted binaries.
+This replaces the heuristic ``strings`` + grep approach with precise
+version-based detection.
+
+Compatibility matrix:
+- Go >= 1.19: native cgroups v2 support in the Go runtime.
+- Go < 1.19 + v2-aware cgroup module at sufficient version: compatible.
+- Go < 1.19 + v2-aware cgroup module below minimum version: needs review.
+- Go < 1.19 + no v2-aware modules: not compatible.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+GO_V2_RUNTIME_VERSION = (1, 19)
+
+GO_V2_AWARE_MODULES = {
+    "go.uber.org/automaxprocs": "v1.5.0",
+    "github.com/KimMachineGun/automemlimit": "v0.1.0",
+    "github.com/containerd/cgroups": "v1.0.0",
+    "github.com/opencontainers/runc/libcontainer/cgroups": "v1.1.0",
+}
+
+_GO_VERSION_RE = re.compile(r"go(\d+)\.(\d+)")
+_GO_DEP_RE = re.compile(r"^\s+dep\s+(\S+)\s+(v\S+)", re.MULTILINE)
+
+
+@dataclass
+class GoBinaryInfo:
+    """Result of analyzing a Go binary with ``go version`` and ``go version -m``."""
+
+    path: str
+    go_version: str
+    modules: dict[str, str] = field(default_factory=dict)
+    is_compatible: bool | None = None
+    compliance_reason: str = ""
+
+
+def parse_go_version(version_str: str) -> tuple[int | None, int | None]:
+    """Parse ``'go1.22.5'`` -> ``(1, 22)``, ``'go1.18'`` -> ``(1, 18)``."""
+    match = _GO_VERSION_RE.match(version_str)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    return None, None
+
+
+def semver_gte(version_a: str, version_b: str) -> bool:
+    """Check if *version_a* >= *version_b* (simple semver with v-prefix)."""
+    def parse(v: str) -> tuple[int, ...]:
+        return tuple(int(p) for p in v.lstrip("v").split(".")[:3])
+    try:
+        return parse(version_a) >= parse(version_b)
+    except (ValueError, IndexError):
+        return False
+
+
+def check_go_compatibility(
+    go_version: str,
+    modules: dict[str, str],
+) -> tuple[bool | None, str]:
+    """Determine Go binary cgroups v2 compatibility.
+
+    Args:
+        go_version: Version string from ``go version``, e.g. ``"go1.22.5"``.
+        modules: All dependency modules from ``go version -m``.
+
+    Returns:
+        Tuple of (is_compatible, reason).
+    """
+    major, minor = parse_go_version(go_version)
+
+    if major is None:
+        return None, f"Cannot parse Go version: {go_version}"
+
+    if (major, minor) >= GO_V2_RUNTIME_VERSION:
+        return True, f"Go {major}.{minor} >= 1.19: runtime native v2 support"
+
+    for mod_path, min_version in GO_V2_AWARE_MODULES.items():
+        if mod_path in modules:
+            detected_version = modules[mod_path]
+            short_name = mod_path.rsplit("/", 1)[-1]
+            if semver_gte(detected_version, min_version):
+                return True, (
+                    f"Go {major}.{minor} < 1.19, but {short_name} "
+                    f"{detected_version} >= {min_version} provides v2 support"
+                )
+            else:
+                return None, (
+                    f"Go {major}.{minor} < 1.19, {short_name} "
+                    f"{detected_version} < {min_version}: needs review"
+                )
+
+    return False, f"Go {major}.{minor} < 1.19, no v2-aware cgroup modules detected"
+
+
+def get_go_version(binary_path: str, debug: bool = False) -> str | None:
+    """Run ``go version <binary_path>`` and return the Go version string.
+
+    Returns:
+        The Go version (e.g. ``"go1.22.5"``), or None if the binary
+        is not a Go binary or ``go`` is not available.
+    """
+    try:
+        result = subprocess.run(
+            ["go", "version", binary_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if debug:
+            logger.debug("go version %s → exit=%d, stdout=%s", binary_path, result.returncode, result.stdout[:200])
+        if result.returncode != 0:
+            return None
+        # Output format: "/path/to/binary: go1.22.5"
+        match = _GO_VERSION_RE.search(result.stdout)
+        if match:
+            return f"go{match.group(1)}.{match.group(2)}"
+        # Try extracting fuller version (with patch) from output
+        full_match = re.search(r"(go\d+\.\d+(?:\.\d+)?)", result.stdout)
+        if full_match:
+            return full_match.group(1)
+        return None
+    except FileNotFoundError:
+        logger.debug("'go' command not found in PATH")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.debug("go version timed out for %s", binary_path)
+        return None
+    except Exception as e:
+        logger.debug("go version error for %s: %s", binary_path, e)
+        return None
+
+
+def get_go_module_info(binary_path: str, debug: bool = False) -> dict[str, str]:
+    """Run ``go version -m <binary_path>`` and parse all module dependencies.
+
+    Returns:
+        Dict of module_path -> version for all ``dep`` lines.
+    """
+    modules: dict[str, str] = {}
+    try:
+        result = subprocess.run(
+            ["go", "version", "-m", binary_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if debug:
+            logger.debug("go version -m %s → exit=%d", binary_path, result.returncode)
+        if result.returncode != 0:
+            return modules
+
+        for match in _GO_DEP_RE.finditer(result.stdout):
+            modules[match.group(1)] = match.group(2)
+
+        return modules
+    except FileNotFoundError:
+        logger.debug("'go' command not found in PATH")
+        return modules
+    except subprocess.TimeoutExpired:
+        logger.debug("go version -m timed out for %s", binary_path)
+        return modules
+    except Exception as e:
+        logger.debug("go version -m error for %s: %s", binary_path, e)
+        return modules
+
+
+def find_go_binaries(
+    extract_path: Path,
+    entrypoint: list[str] | None,
+    cmd: list[str] | None,
+    debug: bool = False,
+) -> list[tuple[str, str, str]]:
+    """Identify Go binaries among entrypoint/cmd references.
+
+    For each reference in entrypoint + cmd, resolves it in the extracted
+    rootfs and runs ``go version`` on it. If it succeeds, the binary is
+    a Go binary.
+
+    Args:
+        extract_path: Path to the extracted container rootfs.
+        entrypoint: ENTRYPOINT from image config.
+        cmd: CMD from image config.
+        debug: Enable debug output.
+
+    Returns:
+        List of (container_path, extracted_path, go_version) tuples.
+    """
+    from .deep_scan import _INTERPRETER_PATHS, _is_elf_binary, _resolve_script_in_rootfs
+
+    combined: list[str] = []
+    if entrypoint:
+        combined.extend(entrypoint)
+    if cmd:
+        combined.extend(cmd)
+
+    if not combined:
+        return []
+
+    results: list[tuple[str, str, str]] = []
+    checked: set[str] = set()
+
+    for ref in combined:
+        if "/" not in ref or ref.startswith("-"):
+            continue
+        if ref in _INTERPRETER_PATHS:
+            continue
+
+        resolved = _resolve_script_in_rootfs(ref, extract_path)
+        if resolved is None:
+            logger.debug("Could not resolve in rootfs: %s", ref)
+            if debug:
+                print(f"      [DEBUG] Could not resolve in rootfs: {ref}")
+            continue
+
+        real_path = str(resolved.resolve())
+        if real_path in checked:
+            continue
+        checked.add(real_path)
+
+        if not _is_elf_binary(resolved):
+            continue
+
+        go_ver = get_go_version(real_path, debug=debug)
+        if go_ver is not None:
+            try:
+                rel = resolved.relative_to(extract_path.resolve())
+                container_path = f"/{rel}"
+            except ValueError:
+                container_path = ref
+            results.append((container_path, real_path, go_ver))
+            logger.debug("Go binary found: %s → %s", container_path, go_ver)
+            if debug:
+                print(f"      [DEBUG] Go binary found: {container_path} → {go_ver}")
+
+    # Also check binaries discovered via exec chains in entrypoint scripts
+    from .deep_scan import scan_entrypoint_scripts
+
+    _, _, discovered_binaries = scan_entrypoint_scripts(
+        extract_path=extract_path,
+        entrypoint_cmd=combined,
+        debug=debug,
+    )
+
+    for bin_ref in discovered_binaries:
+        resolved = _resolve_script_in_rootfs(bin_ref, extract_path)
+        if resolved is None:
+            continue
+        real_path = str(resolved.resolve())
+        if real_path in checked:
+            continue
+        checked.add(real_path)
+
+        if not _is_elf_binary(resolved):
+            continue
+
+        go_ver = get_go_version(real_path, debug=debug)
+        if go_ver is not None:
+            try:
+                rel = resolved.relative_to(extract_path.resolve())
+                container_path = f"/{rel}"
+            except ValueError:
+                container_path = bin_ref
+            results.append((container_path, real_path, go_ver))
+            logger.debug("Go binary found (exec chain): %s → %s", container_path, go_ver)
+            if debug:
+                print(f"      [DEBUG] Go binary found (exec chain): {container_path} → {go_ver}")
+
+    return results

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -148,13 +148,19 @@ class ImageAnalysisResult:
         """Return compatibility status for Go."""
         if not self.go_binaries:
             return "N/A"
-        if any(b.is_compatible is None for b in self.go_binaries):
+        has_needs_review = any(
+            b.is_compatible is None and "needs review" in b.compliance_reason for b in self.go_binaries
+        )
+        has_unknown = any(
+            b.is_compatible is None and "needs review" not in b.compliance_reason for b in self.go_binaries
+        )
+        if has_unknown:
             return "Unknown"
+        if has_needs_review:
+            return "Needs Review"
         compatible = all(b.is_compatible for b in self.go_binaries)
         if compatible:
             return "Yes"
-        if any(b.is_compatible for b in self.go_binaries):
-            return "Needs Review"
         return "No"
 
     @property

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -1,6 +1,6 @@
 """
 Image Analyzer Module
-Analyzes container images for Java, NodeJS, and .NET binaries to check cgroup v2 compatibility.
+Analyzes container images for Java, NodeJS, .NET, and Go binaries to check cgroup v2 compatibility.
 
 Supported runtimes and minimum versions for cgroup v2:
 - OpenJDK / HotSpot: jdk8u372, 11.0.16, 15 and later
@@ -8,6 +8,7 @@ Supported runtimes and minimum versions for cgroup v2:
 - IBM Semeru Runtimes: jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
 - IBM SDK Java Technology Edition (IBM Java): 8.0.7.15 and later
 - .NET: 5.0 and later
+- Go: 1.19 and later (native runtime support), or earlier with v2-aware cgroup modules
 """
 
 import contextlib
@@ -51,9 +52,9 @@ class ImageAnalysisResult:
     java_binaries: list[BinaryInfo] = field(default_factory=list)
     node_binaries: list[BinaryInfo] = field(default_factory=list)
     dotnet_binaries: list[BinaryInfo] = field(default_factory=list)
+    go_binaries: list = field(default_factory=list)  # list[GoBinaryInfo]
     deep_scan_matches: list[DeepScanMatch] = field(default_factory=list)
     deep_scan_v2_aware_flag: bool = False
-    deep_scan_go_cgroup_libs_list: list[str] = field(default_factory=list)
     error: str | None = None
 
     @property
@@ -129,6 +130,45 @@ class ImageAnalysisResult:
         return "Yes" if compatible else "No"
 
     @property
+    def go_found(self) -> str:
+        """Return semicolon-separated list of Go binaries found."""
+        if not self.go_binaries:
+            return "None"
+        return "; ".join([b.path for b in self.go_binaries])
+
+    @property
+    def go_versions(self) -> str:
+        """Return semicolon-separated list of Go versions."""
+        if not self.go_binaries:
+            return "None"
+        return "; ".join([b.go_version for b in self.go_binaries])
+
+    @property
+    def go_compatible(self) -> str:
+        """Return compatibility status for Go."""
+        if not self.go_binaries:
+            return "N/A"
+        if any(b.is_compatible is None for b in self.go_binaries):
+            return "Unknown"
+        compatible = all(b.is_compatible for b in self.go_binaries)
+        if compatible:
+            return "Yes"
+        if any(b.is_compatible for b in self.go_binaries):
+            return "Needs Review"
+        return "No"
+
+    @property
+    def go_modules_str(self) -> str:
+        """Return pipe-separated module info across all Go binaries."""
+        if not self.go_binaries:
+            return "None"
+        all_mods = []
+        for b in self.go_binaries:
+            for mod, ver in b.modules.items():
+                all_mods.append(f"{mod} {ver}")
+        return "|".join(all_mods) if all_mods else "None"
+
+    @property
     def deep_scan_match(self) -> str:
         """Return 'true' if any cgroup v1 pattern was found, 'false' otherwise, '' if not scanned."""
         if not hasattr(self, "deep_scan_matches") or self.deep_scan_matches is None:
@@ -175,17 +215,6 @@ class ImageAnalysisResult:
         if not self.deep_scan_matches:
             return ""
         return "true" if self.deep_scan_v2_aware_flag else "false"
-
-    @property
-    def deep_scan_go_cgroup_libs(self) -> str:
-        """Return pipe-separated Go cgroup library paths detected in binaries.
-
-        Empty string if no deep scan was performed or no libraries detected.
-        """
-        if not self.deep_scan_go_cgroup_libs_list:
-            return ""
-        return "|".join(self.deep_scan_go_cgroup_libs_list)
-
 
 class ImageAnalyzer:
     """
@@ -249,6 +278,7 @@ class ImageAnalyzer:
         internal_registry_route: str | None = None,
         openshift_token: str | None = None,
         deep_scan: bool = False,
+        go_scan: bool = False,
     ):
         """
         Initialize the image analyzer.
@@ -263,6 +293,7 @@ class ImageAnalyzer:
             openshift_token: Bearer token for authenticating to the internal
                 registry route via ``podman login``.
             deep_scan: Enable heuristic deep-scan for cgroup v1 references.
+            go_scan: Enable deterministic Go binary scanning via ``go version``.
         """
         self.rootfs_base = Path(rootfs_base_path).resolve()
         self.rootfs_path = self.rootfs_base / "rootfs"
@@ -270,6 +301,7 @@ class ImageAnalyzer:
         self.internal_registry_route = internal_registry_route
         self.openshift_token = openshift_token
         self.deep_scan = deep_scan
+        self.go_scan = go_scan
         self._registry_logged_in = False
 
         # Ensure rootfs directory exists
@@ -1272,13 +1304,64 @@ class ImageAnalyzer:
                     )
                 )
 
+            # Extract entrypoint/cmd if needed for Go scan or deep-scan
+            entrypoint = None
+            cmd = None
+            if self.go_scan or self.deep_scan:
+                entrypoint, cmd = self._get_image_entrypoint(podman_image, debug=debug)
+
+            if self.go_scan:
+                logger.debug("Searching for Go binaries...")
+                print("    Searching for Go binaries...")
+                from .go_scan import (
+                    GO_V2_AWARE_MODULES,
+                    GoBinaryInfo,
+                    check_go_compatibility,
+                    find_go_binaries,
+                    get_go_module_info,
+                )
+
+                go_binary_infos = find_go_binaries(extract_path, entrypoint, cmd, debug=debug)
+
+                for container_path, extracted_path, go_ver in go_binary_infos:
+                    modules = get_go_module_info(extracted_path, debug=debug)
+
+                    cgroup_modules = {
+                        mod: ver for mod, ver in modules.items()
+                        if mod in GO_V2_AWARE_MODULES
+                    }
+
+                    is_compatible, reason = check_go_compatibility(go_ver, modules)
+
+                    result.go_binaries.append(
+                        GoBinaryInfo(
+                            path=container_path,
+                            go_version=go_ver,
+                            modules=cgroup_modules,
+                            is_compatible=is_compatible,
+                            compliance_reason=reason,
+                        )
+                    )
+
+                if result.go_binaries:
+                    for gb in result.go_binaries:
+                        compat_icon = "✓" if gb.is_compatible else ("?" if gb.is_compatible is None else "✗")
+                        logger.debug("Go binary %s: %s [%s] %s", gb.path, gb.go_version, compat_icon, gb.compliance_reason)
+                        print(f"      {compat_icon} {gb.path}: {gb.go_version} — {gb.compliance_reason}")
+                        if gb.modules:
+                            mods_str = ", ".join(f"{m} {v}" for m, v in gb.modules.items())
+                            logger.debug("  cgroup modules: %s", mods_str)
+                            print(f"        📦 {mods_str}")
+                else:
+                    logger.debug("No Go binaries found")
+                    print("    No Go binaries found")
+
             if self.deep_scan:
                 logger.debug("Running deep-scan for cgroup v1 references...")
                 print("    Running deep-scan for cgroup v1 references...")
-                entrypoint, cmd = self._get_image_entrypoint(podman_image, debug=debug)
                 from .deep_scan import run_deep_scan
 
-                deep_matches, v2_aware, go_libs = run_deep_scan(
+                deep_matches, v2_aware = run_deep_scan(
                     extract_path=extract_path,
                     image_name=podman_image,
                     entrypoint=entrypoint,
@@ -1287,7 +1370,6 @@ class ImageAnalyzer:
                 )
                 result.deep_scan_matches = deep_matches
                 result.deep_scan_v2_aware_flag = v2_aware
-                result.deep_scan_go_cgroup_libs_list = go_libs
 
             if result.java_binaries:
                 for b in result.java_binaries:
@@ -1330,15 +1412,9 @@ class ImageAnalyzer:
                     patterns_str = ", ".join(dict.fromkeys(m.pattern for m in src_matches))
                     logger.debug("  [%s] %s: %s", src_matches[0].confidence, src, patterns_str)
                     print(f"        [{src_matches[0].confidence}] {src}: {patterns_str}")
-                if result.deep_scan_go_cgroup_libs_list:
-                    logger.debug("Go cgroup libraries: %s", ", ".join(result.deep_scan_go_cgroup_libs_list))
-                    print(f"      📦 Go cgroup libraries: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
             elif self.deep_scan:
                 logger.debug("Deep-scan: no cgroup v1 references found")
                 print("      ✓ Deep-scan: no cgroup v1 references found")
-                if result.deep_scan_go_cgroup_libs_list:
-                    logger.debug("Go cgroup libraries detected: %s", ", ".join(result.deep_scan_go_cgroup_libs_list))
-                    print(f"      📦 Go cgroup libraries detected: {', '.join(result.deep_scan_go_cgroup_libs_list)}")
 
             if not result.java_binaries and not result.node_binaries and not result.dotnet_binaries:
                 logger.debug("No Java, Node.js, or .NET binaries found")

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -216,6 +216,7 @@ class ImageAnalysisResult:
             return ""
         return "true" if self.deep_scan_v2_aware_flag else "false"
 
+
 class ImageAnalyzer:
     """
     Analyzes container images for Java, NodeJS, and .NET binaries.
@@ -1326,10 +1327,7 @@ class ImageAnalyzer:
                 for container_path, extracted_path, go_ver in go_binary_infos:
                     modules = get_go_module_info(extracted_path, debug=debug)
 
-                    cgroup_modules = {
-                        mod: ver for mod, ver in modules.items()
-                        if mod in GO_V2_AWARE_MODULES
-                    }
+                    cgroup_modules = {mod: ver for mod, ver in modules.items() if mod in GO_V2_AWARE_MODULES}
 
                     is_compatible, reason = check_go_compatibility(go_ver, modules)
 
@@ -1346,7 +1344,9 @@ class ImageAnalyzer:
                 if result.go_binaries:
                     for gb in result.go_binaries:
                         compat_icon = "✓" if gb.is_compatible else ("?" if gb.is_compatible is None else "✗")
-                        logger.debug("Go binary %s: %s [%s] %s", gb.path, gb.go_version, compat_icon, gb.compliance_reason)
+                        logger.debug(
+                            "Go binary %s: %s [%s] %s", gb.path, gb.go_version, compat_icon, gb.compliance_reason
+                        )
                         print(f"      {compat_icon} {gb.path}: {gb.go_version} — {gb.compliance_reason}")
                         if gb.modules:
                             mods_str = ", ".join(f"{m} {v}" for m, v in gb.modules.items())

--- a/src/registry_collector.py
+++ b/src/registry_collector.py
@@ -33,12 +33,15 @@ CSV_COLUMNS = [
     "dotnet_binary",
     "dotnet_version",
     "dotnet_cgroup_v2_compatible",
+    "go_binary",
+    "go_version",
+    "go_cgroup_v2_compatible",
+    "go_modules",
     "deep_scan_match",
     "deep_scan_confidence",
     "deep_scan_sources",
     "deep_scan_patterns",
     "deep_scan_v2_aware",
-    "deep_scan_go_cgroup_libs",
     "analysis_error",
 ]
 

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -15,7 +15,7 @@ import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-STATE_VERSION = 5
+STATE_VERSION = 6
 
 ANALYSIS_KEYS = (
     "java_binary",
@@ -27,12 +27,15 @@ ANALYSIS_KEYS = (
     "dotnet_binary",
     "dotnet_version",
     "dotnet_cgroup_v2_compatible",
+    "go_binary",
+    "go_version",
+    "go_cgroup_v2_compatible",
+    "go_modules",
     "deep_scan_match",
     "deep_scan_confidence",
     "deep_scan_sources",
     "deep_scan_patterns",
     "deep_scan_v2_aware",
-    "deep_scan_go_cgroup_libs",
     "analysis_error",
 )
 

--- a/tests/test_analysis_orchestrator.py
+++ b/tests/test_analysis_orchestrator.py
@@ -372,6 +372,7 @@ class TestAnalysisOrchestratorOpenShift:
                 "registry.apps.example.com",
                 "sha256~token123",
                 deep_scan=False,
+                go_scan=False,
             )
 
     def test_openshift_token_passed_to_analyzer(self):
@@ -670,7 +671,6 @@ class TestApplyResultsDeepScan:
         assert images[0]["deep_scan_sources"] == "/entry.sh"
         assert images[0]["deep_scan_patterns"] == "memory.limit_in_bytes"
         assert images[0]["deep_scan_v2_aware"] == "false"
-        assert images[0]["deep_scan_go_cgroup_libs"] == ""
 
     def test_deep_scan_fields_empty_when_no_matches(self):
         images = [{"image_name": "test:latest"}]
@@ -682,15 +682,37 @@ class TestApplyResultsDeepScan:
         assert images[0]["deep_scan_sources"] == ""
         assert images[0]["deep_scan_patterns"] == ""
         assert images[0]["deep_scan_v2_aware"] == ""
-        assert images[0]["deep_scan_go_cgroup_libs"] == ""
 
-    def test_deep_scan_go_libs_mapped(self):
+    def test_go_fields_mapped(self):
+        from src.go_scan import GoBinaryInfo
+
         images = [{"image_name": "test:latest"}]
         result = ImageAnalysisResult(
             image_name="test:latest",
             image_id="abc",
-            deep_scan_go_cgroup_libs_list=["github.com/prometheus/procfs"],
+            go_binaries=[
+                GoBinaryInfo(
+                    path="/usr/local/bin/app",
+                    go_version="go1.22.5",
+                    modules={"go.uber.org/automaxprocs": "v1.6.0"},
+                    is_compatible=True,
+                    compliance_reason="Go 1.22 >= 1.19: runtime native v2 support",
+                ),
+            ],
         )
         cache = {"test:latest": result}
         AnalysisOrchestrator._apply_results(images, cache)
-        assert images[0]["deep_scan_go_cgroup_libs"] == "github.com/prometheus/procfs"
+        assert images[0]["go_binary"] == "/usr/local/bin/app"
+        assert images[0]["go_version"] == "go1.22.5"
+        assert images[0]["go_cgroup_v2_compatible"] == "Yes"
+        assert images[0]["go_modules"] == "go.uber.org/automaxprocs v1.6.0"
+
+    def test_go_fields_empty_when_no_binaries(self):
+        images = [{"image_name": "test:latest"}]
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        cache = {"test:latest": result}
+        AnalysisOrchestrator._apply_results(images, cache)
+        assert images[0]["go_binary"] == "None"
+        assert images[0]["go_version"] == "None"
+        assert images[0]["go_cgroup_v2_compatible"] == "N/A"
+        assert images[0]["go_modules"] == "None"

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -1056,5 +1056,3 @@ exec "$@"
             debug=False,
         )
         assert not any("binary:/bin/bash" in m.source for m in matches)
-
-

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -10,7 +10,6 @@ from src.deep_scan import (
     CGROUPV1_REGEX,
     CGROUPV2_FILE_NAMES,
     CGROUPV2_REGEX,
-    GO_CGROUP_PACKAGES,
     _extract_sourced_paths,
     _is_elf_binary,
     _is_shell_script,
@@ -18,7 +17,6 @@ from src.deep_scan import (
     _run_strings,
     find_cgroupv1_patterns,
     find_cgroupv2_patterns,
-    find_go_cgroup_deps,
     run_deep_scan,
     scan_binary_strings,
     scan_entrypoint_scripts,
@@ -663,7 +661,7 @@ MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 exec "$@"
 """,
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -674,7 +672,7 @@ exec "$@"
         assert v2_aware is False
 
     def test_without_entrypoint(self, tmp_path):
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=None,
@@ -695,7 +693,7 @@ else
 fi
 """,
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -706,7 +704,7 @@ fi
 
     def test_debug_does_not_crash(self, tmp_path):
         """Debug mode should not raise exceptions."""
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             debug=True,
@@ -791,7 +789,7 @@ class TestScanBinaryStrings:
                 "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
             ],
         )
-        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        matches, v2_aware = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert len(matches) > 0
         assert all(m.confidence == "low" for m in matches)
         assert all(m.source.startswith("binary:") for m in matches)
@@ -807,7 +805,7 @@ class TestScanBinaryStrings:
                 "memory.max_is_a_long_enough_string",
             ],
         )
-        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
+        matches, v2_aware = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
         assert len(matches) > 0
         assert v2_aware is True
 
@@ -816,19 +814,19 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "cleanapp",
             ["just_some_random_long_string_here", "another_normal_string_data"],
         )
-        matches, v2_aware, _ = scan_binary_strings(tmp_path, ["/usr/bin/cleanapp"], debug=False)
+        matches, v2_aware = scan_binary_strings(tmp_path, ["/usr/bin/cleanapp"], debug=False)
         assert matches == []
         assert v2_aware is False
 
     def test_nonexistent_binary_skipped(self, tmp_path):
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/nonexistent"], debug=False)
+        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/nonexistent"], debug=False)
         assert matches == []
 
     def test_shell_script_skipped(self, tmp_path):
         script = tmp_path / "usr" / "bin" / "run.sh"
         script.parent.mkdir(parents=True)
         script.write_text("#!/bin/bash\ncat /sys/fs/cgroup/memory/memory.limit_in_bytes")
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/run.sh"], debug=False)
+        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/run.sh"], debug=False)
         assert matches == []
 
     def test_multiple_binaries(self, tmp_path):
@@ -840,7 +838,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "app2",
             ["/sys/fs/cgroup/cpu/cpu.cfs_quota_us"],
         )
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
+        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
         assert len(matches) >= 2
         sources = {m.source for m in matches}
         assert "binary:/usr/bin/app1" in sources
@@ -851,7 +849,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False)
+        matches, _ = scan_binary_strings(tmp_path, ["/usr/bin/myapp", "/usr/bin/myapp"], debug=False)
         pattern_count = sum(1 for m in matches if m.pattern == "memory.limit_in_bytes")
         assert pattern_count == 1
 
@@ -861,7 +859,7 @@ class TestScanBinaryStrings:
             tmp_path / "usr" / "local" / "bin" / "cgroup-reader",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = scan_binary_strings(tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False)
+        matches, _ = scan_binary_strings(tmp_path, ["/usr/local/bin/cgroup-reader"], debug=False)
         assert len(matches) > 0
         assert matches[0].source == "binary:/usr/local/bin/cgroup-reader"
 
@@ -892,7 +890,7 @@ class TestRunDeepScanWithBinary:
                 "/sys/fs/cgroup/cpuacct/cpuacct.usage",
             ],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="cadvisor:v0.44.0",
             entrypoint=["/usr/bin/cadvisor"],
@@ -911,7 +909,7 @@ MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 exec "$@"
 """,
         )
-        matches, _, _ = run_deep_scan(
+        matches, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -931,7 +929,7 @@ exec "$@"
                 "memory.max_and_some_padding",
             ],
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="monitor:latest",
             entrypoint=["/usr/bin/monitor"],
@@ -953,7 +951,7 @@ exec "$@"
             tmp_path / "usr" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/wrapper.sh"],
@@ -970,7 +968,7 @@ exec "$@"
             tmp_path / "usr" / "bin" / "nginx",
             ["welcome_to_nginx_server", "http_proxy_module_loaded"],
         )
-        matches, v2_aware, _ = run_deep_scan(
+        matches, v2_aware = run_deep_scan(
             extract_path=tmp_path,
             image_name="nginx:latest",
             entrypoint=["/usr/bin/nginx"],
@@ -995,7 +993,7 @@ exec /usr/local/bin/myapp
                 "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
             ],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1018,7 +1016,7 @@ exec /usr/local/bin/myapp
             tmp_path / "usr" / "local" / "bin" / "myapp",
             ["/sys/fs/cgroup/memory/memory.limit_in_bytes"],
         )
-        matches, _, _ = run_deep_scan(
+        matches, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1050,7 +1048,7 @@ echo hello
 exec "$@"
 """,
         )
-        matches, _, _ = run_deep_scan(
+        matches, _ = run_deep_scan(
             extract_path=tmp_path,
             image_name="test:latest",
             entrypoint=["/entrypoint.sh"],
@@ -1060,148 +1058,3 @@ exec "$@"
         assert not any("binary:/bin/bash" in m.source for m in matches)
 
 
-class TestGoCgroupPackages:
-    """Verify Go package constants are well-formed."""
-
-    def test_no_duplicates(self):
-        assert len(GO_CGROUP_PACKAGES) == len(set(GO_CGROUP_PACKAGES))
-
-    def test_all_contain_slash_or_runtime(self):
-        for pkg in GO_CGROUP_PACKAGES:
-            assert "/" in pkg or pkg.startswith("runtime/"), f"{pkg} should contain / or start with runtime/"
-
-
-class TestFindGoCgroupDeps:
-    """Tests for find_go_cgroup_deps()."""
-
-    def test_empty_string(self):
-        assert find_go_cgroup_deps("") == []
-
-    def test_finds_procfs(self):
-        text = """
-runtime.goexit
-github.com/prometheus/procfs
-net/http
-"""
-        result = find_go_cgroup_deps(text)
-        assert "github.com/prometheus/procfs" in result
-
-    def test_finds_multiple_packages(self):
-        text = """
-github.com/opencontainers/runc/libcontainer/cgroups
-github.com/prometheus/procfs
-go.uber.org/automaxprocs
-"""
-        result = find_go_cgroup_deps(text)
-        assert len(result) == 3
-
-    def test_no_match_on_unrelated_packages(self):
-        text = """
-github.com/gorilla/mux
-golang.org/x/net
-encoding/json
-"""
-        assert find_go_cgroup_deps(text) == []
-
-    def test_deduplicated(self):
-        text = """
-github.com/prometheus/procfs
-github.com/prometheus/procfs/internal
-github.com/prometheus/procfs
-"""
-        result = find_go_cgroup_deps(text)
-        assert result.count("github.com/prometheus/procfs") == 1
-
-    def test_cadvisor_packages(self):
-        text = """
-github.com/google/cadvisor/container
-github.com/google/cadvisor/cgroup
-"""
-        result = find_go_cgroup_deps(text)
-        assert "github.com/google/cadvisor/container" in result
-        assert "github.com/google/cadvisor/cgroup" in result
-
-    def test_containerd_cgroups(self):
-        text = "github.com/containerd/cgroups"
-        result = find_go_cgroup_deps(text)
-        assert "github.com/containerd/cgroups" in result
-
-    def test_automaxprocs(self):
-        text = "go.uber.org/automaxprocs"
-        result = find_go_cgroup_deps(text)
-        assert "go.uber.org/automaxprocs" in result
-
-
-class TestScanBinaryStringsGoDeps:
-    """Tests for Go dep detection in scan_binary_strings."""
-
-    def _create_binary_with_strings(self, path: Path, embedded_strings: list[str]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        content = b"\x7fELF" + b"\x00" * 100
-        for s in embedded_strings:
-            content += s.encode("utf-8") + b"\x00" * 10
-        content += b"\x00" * 100
-        path.write_bytes(content)
-
-    def test_go_deps_returned(self, tmp_path):
-        self._create_binary_with_strings(
-            tmp_path / "usr" / "bin" / "exporter",
-            [
-                "github.com/prometheus/procfs",
-                "net/http.ListenAndServe",
-            ],
-        )
-        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
-        assert "github.com/prometheus/procfs" in go_libs
-
-    def test_go_deps_without_v1_patterns(self, tmp_path):
-        """Binary with Go cgroup libs but no direct v1 patterns."""
-        self._create_binary_with_strings(
-            tmp_path / "usr" / "bin" / "exporter",
-            [
-                "github.com/prometheus/procfs",
-                "just_some_normal_long_text_here",
-            ],
-        )
-        matches, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/exporter"], debug=False)
-        assert matches == []
-        assert "github.com/prometheus/procfs" in go_libs
-
-    def test_go_deps_with_v1_patterns(self, tmp_path):
-        """Binary with both Go cgroup libs AND v1 patterns."""
-        self._create_binary_with_strings(
-            tmp_path / "usr" / "bin" / "cadvisor",
-            [
-                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
-                "github.com/google/cadvisor/container",
-                "github.com/opencontainers/runc/libcontainer/cgroups",
-            ],
-        )
-        matches, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/cadvisor"], debug=False)
-        assert len(matches) > 0
-        assert len(go_libs) >= 2
-
-    def test_no_go_deps_in_non_go_binary(self, tmp_path):
-        """C binary without Go packages."""
-        self._create_binary_with_strings(
-            tmp_path / "usr" / "bin" / "myapp",
-            [
-                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
-                "libc.so.6_is_a_long_string",
-            ],
-        )
-        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/myapp"], debug=False)
-        assert go_libs == []
-
-    def test_go_deps_deduplicated_across_binaries(self, tmp_path):
-        """Same Go package in two binaries should appear once."""
-        self._create_binary_with_strings(
-            tmp_path / "usr" / "bin" / "app1",
-            ["github.com/prometheus/procfs"],
-        )
-        self._create_binary_with_strings(
-            tmp_path / "usr" / "bin" / "app2",
-            ["github.com/prometheus/procfs"],
-        )
-        _, _, go_libs = scan_binary_strings(tmp_path, ["/usr/bin/app1", "/usr/bin/app2"], debug=False)
-        assert go_libs.count("github.com/prometheus/procfs") == 1

--- a/tests/test_go_scan.py
+++ b/tests/test_go_scan.py
@@ -89,51 +89,37 @@ class TestCheckGoCompatibility:
         assert "runtime native v2 support" in reason
 
     def test_go_1_22_with_modules(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.22", {"go.uber.org/automaxprocs": "v1.6.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.22", {"go.uber.org/automaxprocs": "v1.6.0"})
         assert is_compat is True
         assert "runtime native" in reason
 
     def test_go_1_18_automaxprocs_v1_6_0(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"go.uber.org/automaxprocs": "v1.6.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"go.uber.org/automaxprocs": "v1.6.0"})
         assert is_compat is True
         assert "automaxprocs" in reason
 
     def test_go_1_18_automaxprocs_v1_5_1(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"go.uber.org/automaxprocs": "v1.5.1"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"go.uber.org/automaxprocs": "v1.5.1"})
         assert is_compat is True
         assert "automaxprocs" in reason
 
     def test_go_1_18_automaxprocs_v1_5_0(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"go.uber.org/automaxprocs": "v1.5.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"go.uber.org/automaxprocs": "v1.5.0"})
         assert is_compat is True
         assert "automaxprocs" in reason
 
     def test_go_1_18_automaxprocs_v1_4_0_needs_review(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"go.uber.org/automaxprocs": "v1.4.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"go.uber.org/automaxprocs": "v1.4.0"})
         assert is_compat is None
         assert "needs review" in reason
 
     def test_go_1_18_automemlimit_v0_7_0(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"github.com/KimMachineGun/automemlimit": "v0.7.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"github.com/KimMachineGun/automemlimit": "v0.7.0"})
         assert is_compat is True
         assert "automemlimit" in reason
 
     def test_go_1_18_automemlimit_v0_1_0(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"github.com/KimMachineGun/automemlimit": "v0.1.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"github.com/KimMachineGun/automemlimit": "v0.1.0"})
         assert is_compat is True
         assert "automemlimit" in reason
 
@@ -143,9 +129,7 @@ class TestCheckGoCompatibility:
         assert "no v2-aware" in reason
 
     def test_go_1_18_unknown_module_only(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.18", {"github.com/gorilla/mux": "v1.8.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.18", {"github.com/gorilla/mux": "v1.8.0"})
         assert is_compat is False
         assert "no v2-aware" in reason
 
@@ -155,9 +139,7 @@ class TestCheckGoCompatibility:
         assert "Cannot parse" in reason
 
     def test_containerd_cgroups_v1_0_0(self):
-        is_compat, reason = check_go_compatibility(
-            "go1.17", {"github.com/containerd/cgroups": "v1.0.0"}
-        )
+        is_compat, reason = check_go_compatibility("go1.17", {"github.com/containerd/cgroups": "v1.0.0"})
         assert is_compat is True
         assert "cgroups" in reason
 
@@ -271,21 +253,15 @@ class TestImageAnalysisResultGoProperties:
 
     def test_multiple_binaries_paths(self):
         result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
-        result.go_binaries.append(
-            GoBinaryInfo(path="/bin/a", go_version="go1.22", is_compatible=True)
-        )
-        result.go_binaries.append(
-            GoBinaryInfo(path="/bin/b", go_version="go1.21", is_compatible=True)
-        )
+        result.go_binaries.append(GoBinaryInfo(path="/bin/a", go_version="go1.22", is_compatible=True))
+        result.go_binaries.append(GoBinaryInfo(path="/bin/b", go_version="go1.21", is_compatible=True))
         assert result.go_found == "/bin/a; /bin/b"
         assert result.go_versions == "go1.22; go1.21"
         assert result.go_compatible == "Yes"
 
     def test_modules_str_no_modules(self):
         result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
-        result.go_binaries.append(
-            GoBinaryInfo(path="/bin/a", go_version="go1.22", modules={}, is_compatible=True)
-        )
+        result.go_binaries.append(GoBinaryInfo(path="/bin/a", go_version="go1.22", modules={}, is_compatible=True))
         assert result.go_modules_str == "None"
 
     def test_modules_str_multiple_modules(self):

--- a/tests/test_go_scan.py
+++ b/tests/test_go_scan.py
@@ -218,7 +218,7 @@ class TestImageAnalysisResultGoProperties:
         )
         assert result.go_compatible == "No"
 
-    def test_unknown_compatibility(self):
+    def test_needs_review_compatibility(self):
         result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
         result.go_binaries.append(
             GoBinaryInfo(
@@ -227,6 +227,18 @@ class TestImageAnalysisResultGoProperties:
                 modules={"go.uber.org/automaxprocs": "v1.4.0"},
                 is_compatible=None,
                 compliance_reason="needs review",
+            )
+        )
+        assert result.go_compatible == "Needs Review"
+
+    def test_unknown_compatibility(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/weird",
+                go_version="goXYZ",
+                is_compatible=None,
+                compliance_reason="Cannot parse Go version: goXYZ",
             )
         )
         assert result.go_compatible == "Unknown"
@@ -247,6 +259,27 @@ class TestImageAnalysisResultGoProperties:
                 go_version="go1.16",
                 is_compatible=False,
                 compliance_reason="no v2",
+            )
+        )
+        assert result.go_compatible == "No"
+
+    def test_mixed_compatible_and_needs_review(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/new",
+                go_version="go1.22",
+                is_compatible=True,
+                compliance_reason="native",
+            )
+        )
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/old",
+                go_version="go1.18",
+                modules={"go.uber.org/automaxprocs": "v1.4.0"},
+                is_compatible=None,
+                compliance_reason="automaxprocs v1.4.0 < v1.5.0: needs review",
             )
         )
         assert result.go_compatible == "Needs Review"

--- a/tests/test_go_scan.py
+++ b/tests/test_go_scan.py
@@ -1,0 +1,329 @@
+"""Tests for the go_scan module — Go binary cgroups v2 compatibility logic."""
+
+from src.go_scan import (
+    GO_V2_AWARE_MODULES,
+    GO_V2_RUNTIME_VERSION,
+    GoBinaryInfo,
+    check_go_compatibility,
+    parse_go_version,
+    semver_gte,
+)
+from src.image_analyzer import ImageAnalysisResult
+
+# ---------------------------------------------------------------------------
+# parse_go_version
+# ---------------------------------------------------------------------------
+
+
+class TestParseGoVersion:
+    def test_full_version(self):
+        assert parse_go_version("go1.22.5") == (1, 22)
+
+    def test_minor_only(self):
+        assert parse_go_version("go1.18") == (1, 18)
+
+    def test_release_candidate(self):
+        assert parse_go_version("go1.22rc1") == (1, 22)
+
+    def test_invalid(self):
+        assert parse_go_version("not-go") == (None, None)
+
+    def test_empty(self):
+        assert parse_go_version("") == (None, None)
+
+    def test_go1_19(self):
+        assert parse_go_version("go1.19") == (1, 19)
+
+    def test_go1_21_3(self):
+        assert parse_go_version("go1.21.3") == (1, 21)
+
+
+# ---------------------------------------------------------------------------
+# semver_gte
+# ---------------------------------------------------------------------------
+
+
+class TestSemverGte:
+    def test_greater(self):
+        assert semver_gte("v1.5.1", "v1.5.0") is True
+
+    def test_less(self):
+        assert semver_gte("v1.4.0", "v1.5.0") is False
+
+    def test_equal(self):
+        assert semver_gte("v1.5.0", "v1.5.0") is True
+
+    def test_major_greater(self):
+        assert semver_gte("v2.0.0", "v1.9.9") is True
+
+    def test_major_less(self):
+        assert semver_gte("v0.9.0", "v1.0.0") is False
+
+    def test_patch_greater(self):
+        assert semver_gte("v1.5.2", "v1.5.1") is True
+
+    def test_no_v_prefix(self):
+        assert semver_gte("1.5.0", "1.5.0") is True
+
+    def test_invalid_version_a(self):
+        assert semver_gte("invalid", "v1.0.0") is False
+
+    def test_invalid_version_b(self):
+        assert semver_gte("v1.0.0", "invalid") is False
+
+
+# ---------------------------------------------------------------------------
+# check_go_compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestCheckGoCompatibility:
+    def test_go_1_22_native_support(self):
+        is_compat, reason = check_go_compatibility("go1.22.5", {})
+        assert is_compat is True
+        assert "runtime native v2 support" in reason
+
+    def test_go_1_19_native_support(self):
+        is_compat, reason = check_go_compatibility("go1.19", {})
+        assert is_compat is True
+        assert "runtime native v2 support" in reason
+
+    def test_go_1_22_with_modules(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.22", {"go.uber.org/automaxprocs": "v1.6.0"}
+        )
+        assert is_compat is True
+        assert "runtime native" in reason
+
+    def test_go_1_18_automaxprocs_v1_6_0(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"go.uber.org/automaxprocs": "v1.6.0"}
+        )
+        assert is_compat is True
+        assert "automaxprocs" in reason
+
+    def test_go_1_18_automaxprocs_v1_5_1(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"go.uber.org/automaxprocs": "v1.5.1"}
+        )
+        assert is_compat is True
+        assert "automaxprocs" in reason
+
+    def test_go_1_18_automaxprocs_v1_5_0(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"go.uber.org/automaxprocs": "v1.5.0"}
+        )
+        assert is_compat is True
+        assert "automaxprocs" in reason
+
+    def test_go_1_18_automaxprocs_v1_4_0_needs_review(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"go.uber.org/automaxprocs": "v1.4.0"}
+        )
+        assert is_compat is None
+        assert "needs review" in reason
+
+    def test_go_1_18_automemlimit_v0_7_0(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"github.com/KimMachineGun/automemlimit": "v0.7.0"}
+        )
+        assert is_compat is True
+        assert "automemlimit" in reason
+
+    def test_go_1_18_automemlimit_v0_1_0(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"github.com/KimMachineGun/automemlimit": "v0.1.0"}
+        )
+        assert is_compat is True
+        assert "automemlimit" in reason
+
+    def test_go_1_18_no_cgroup_modules(self):
+        is_compat, reason = check_go_compatibility("go1.18", {})
+        assert is_compat is False
+        assert "no v2-aware" in reason
+
+    def test_go_1_18_unknown_module_only(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.18", {"github.com/gorilla/mux": "v1.8.0"}
+        )
+        assert is_compat is False
+        assert "no v2-aware" in reason
+
+    def test_unparseable_version(self):
+        is_compat, reason = check_go_compatibility("notgo", {})
+        assert is_compat is None
+        assert "Cannot parse" in reason
+
+    def test_containerd_cgroups_v1_0_0(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.17", {"github.com/containerd/cgroups": "v1.0.0"}
+        )
+        assert is_compat is True
+        assert "cgroups" in reason
+
+    def test_runc_libcontainer_v1_1_0(self):
+        is_compat, reason = check_go_compatibility(
+            "go1.16", {"github.com/opencontainers/runc/libcontainer/cgroups": "v1.1.0"}
+        )
+        assert is_compat is True
+        assert "cgroups" in reason
+
+
+# ---------------------------------------------------------------------------
+# GoBinaryInfo
+# ---------------------------------------------------------------------------
+
+
+class TestGoBinaryInfo:
+    def test_basic_creation(self):
+        info = GoBinaryInfo(
+            path="/usr/local/bin/app",
+            go_version="go1.22.5",
+            modules={"go.uber.org/automaxprocs": "v1.6.0"},
+            is_compatible=True,
+            compliance_reason="Go 1.22 >= 1.19: runtime native v2 support",
+        )
+        assert info.path == "/usr/local/bin/app"
+        assert info.go_version == "go1.22.5"
+        assert info.is_compatible is True
+
+    def test_default_values(self):
+        info = GoBinaryInfo(path="/bin/app", go_version="go1.18")
+        assert info.modules == {}
+        assert info.is_compatible is None
+        assert info.compliance_reason == ""
+
+
+# ---------------------------------------------------------------------------
+# ImageAnalysisResult Go properties
+# ---------------------------------------------------------------------------
+
+
+class TestImageAnalysisResultGoProperties:
+    def test_no_go_binaries(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        assert result.go_found == "None"
+        assert result.go_versions == "None"
+        assert result.go_compatible == "N/A"
+        assert result.go_modules_str == "None"
+
+    def test_single_compatible_binary(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/local/bin/app",
+                go_version="go1.22.5",
+                modules={"go.uber.org/automaxprocs": "v1.6.0"},
+                is_compatible=True,
+                compliance_reason="native v2",
+            )
+        )
+        assert result.go_found == "/usr/local/bin/app"
+        assert result.go_versions == "go1.22.5"
+        assert result.go_compatible == "Yes"
+        assert result.go_modules_str == "go.uber.org/automaxprocs v1.6.0"
+
+    def test_single_incompatible_binary(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/old",
+                go_version="go1.16",
+                modules={},
+                is_compatible=False,
+                compliance_reason="no v2 support",
+            )
+        )
+        assert result.go_compatible == "No"
+
+    def test_unknown_compatibility(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/mystery",
+                go_version="go1.18",
+                modules={"go.uber.org/automaxprocs": "v1.4.0"},
+                is_compatible=None,
+                compliance_reason="needs review",
+            )
+        )
+        assert result.go_compatible == "Unknown"
+
+    def test_mixed_compatible_and_incompatible(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/new",
+                go_version="go1.22",
+                is_compatible=True,
+                compliance_reason="native",
+            )
+        )
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/usr/bin/old",
+                go_version="go1.16",
+                is_compatible=False,
+                compliance_reason="no v2",
+            )
+        )
+        assert result.go_compatible == "Needs Review"
+
+    def test_multiple_binaries_paths(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(path="/bin/a", go_version="go1.22", is_compatible=True)
+        )
+        result.go_binaries.append(
+            GoBinaryInfo(path="/bin/b", go_version="go1.21", is_compatible=True)
+        )
+        assert result.go_found == "/bin/a; /bin/b"
+        assert result.go_versions == "go1.22; go1.21"
+        assert result.go_compatible == "Yes"
+
+    def test_modules_str_no_modules(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(path="/bin/a", go_version="go1.22", modules={}, is_compatible=True)
+        )
+        assert result.go_modules_str == "None"
+
+    def test_modules_str_multiple_modules(self):
+        result = ImageAnalysisResult(image_name="test:latest", image_id="abc")
+        result.go_binaries.append(
+            GoBinaryInfo(
+                path="/bin/a",
+                go_version="go1.22",
+                modules={
+                    "go.uber.org/automaxprocs": "v1.6.0",
+                    "github.com/KimMachineGun/automemlimit": "v0.7.0",
+                },
+                is_compatible=True,
+            )
+        )
+        mods = result.go_modules_str
+        assert "go.uber.org/automaxprocs v1.6.0" in mods
+        assert "github.com/KimMachineGun/automemlimit v0.7.0" in mods
+        assert "|" in mods
+
+
+# ---------------------------------------------------------------------------
+# GO_V2_AWARE_MODULES constants
+# ---------------------------------------------------------------------------
+
+
+class TestGoConstants:
+    def test_runtime_version_tuple(self):
+        assert GO_V2_RUNTIME_VERSION == (1, 19)
+
+    def test_aware_modules_has_automaxprocs(self):
+        assert "go.uber.org/automaxprocs" in GO_V2_AWARE_MODULES
+
+    def test_aware_modules_has_automemlimit(self):
+        assert "github.com/KimMachineGun/automemlimit" in GO_V2_AWARE_MODULES
+
+    def test_aware_modules_has_containerd_cgroups(self):
+        assert "github.com/containerd/cgroups" in GO_V2_AWARE_MODULES
+
+    def test_aware_modules_has_runc_cgroups(self):
+        assert "github.com/opencontainers/runc/libcontainer/cgroups" in GO_V2_AWARE_MODULES

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -789,4 +789,3 @@ class TestDeepScanResult:
     def test_v2_aware_empty_when_no_matches(self):
         result = ImageAnalysisResult("t", "")
         assert result.deep_scan_v2_aware == ""
-

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -790,17 +790,3 @@ class TestDeepScanResult:
         result = ImageAnalysisResult("t", "")
         assert result.deep_scan_v2_aware == ""
 
-    def test_go_cgroup_libs_property(self):
-        result = ImageAnalysisResult(
-            "t",
-            "",
-            deep_scan_go_cgroup_libs_list=[
-                "github.com/prometheus/procfs",
-                "github.com/containerd/cgroups",
-            ],
-        )
-        assert result.deep_scan_go_cgroup_libs == "github.com/prometheus/procfs|github.com/containerd/cgroups"
-
-    def test_go_cgroup_libs_empty(self):
-        result = ImageAnalysisResult("t", "")
-        assert result.deep_scan_go_cgroup_libs == ""


### PR DESCRIPTION
Replace the heuristic strings+grep approach for Go cgroup detection with precise version-based analysis using `go version` and `go version -m`. New compatibility matrix: Go >= 1.19 is natively compatible; older versions are checked against v2-aware module versions. Adds --disable-go CLI flag, four new CSV columns (go_binary, go_version, go_cgroup_v2_compatible, go_modules), and removes the deprecated deep_scan_go_cgroup_libs column.