### PR TITLE
Add Node.js sibling-lookup fallback for musl/Alpine binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project will be documented in this file.
   (`manifests/quay/quay-setup.sh`, `manifests/quay/quay-teardown.sh`)
 - Comprehensive unit tests for all new modules
 - CLI integration tests for registry mode
+- Node.js sibling-lookup fallback: when a `nodeXX_alpine` / `nodeXX_musl`
+  binary fails to execute due to a libc / dynamic-linker mismatch (e.g.
+  GitHub Actions Runner images shipping both glibc and musl builds
+  side-by-side), the version is now inferred from the paired glibc
+  sibling binary at the same installation path. This turns previously
+  "Unknown" rows into deterministic "Yes" / "No" cgroup v2 compatibility
+  verdicts. Cached state files are not invalidated: delete
+  `.state_<target>.json` manually to re-scan affected images with the
+  new logic.
 
 ### Changed
 - Main script now supports dual-mode operation

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -280,9 +280,7 @@ class ImageAnalyzer:
     # output. When a musl (Alpine) binary is run inside a glibc image (or
     # vice versa), the OCI runtime reports something like:
     #   exec container process (missing dynamic library?) `...`: No such file or directory
-    LIBC_MISMATCH_MARKERS = (
-        "missing dynamic library",
-    )
+    LIBC_MISMATCH_MARKERS = ("missing dynamic library",)
 
     # Directory-name suffixes that identify a libc variant of a node
     # installation (typically used by the GitHub Actions Runner and similar
@@ -1357,8 +1355,7 @@ class ImageAnalyzer:
                 )
                 if debug:
                     print(
-                        f"      [DEBUG] Node.js: inferred {inferred_version} from sibling "
-                        f"for {b.path} (libc variant)"
+                        f"      [DEBUG] Node.js: inferred {inferred_version} from sibling for {b.path} (libc variant)"
                     )
                 b.version = inferred_version
                 b.is_compatible = inferred_compat

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -276,6 +276,19 @@ class ImageAnalyzer:
     IBM_SEMERU_PATTERN = re.compile(r"IBM Semeru", re.IGNORECASE)
     IBM_SDK_PATTERN = re.compile(r"IBM (?:J9|SDK)", re.IGNORECASE)
 
+    # Markers that identify a libc / dynamic-linker mismatch in podman/crun
+    # output. When a musl (Alpine) binary is run inside a glibc image (or
+    # vice versa), the OCI runtime reports something like:
+    #   exec container process (missing dynamic library?) `...`: No such file or directory
+    LIBC_MISMATCH_MARKERS = (
+        "missing dynamic library",
+    )
+
+    # Directory-name suffixes that identify a libc variant of a node
+    # installation (typically used by the GitHub Actions Runner and similar
+    # tooling that ships both glibc and musl builds side-by-side).
+    NODE_LIBC_VARIANT_SUFFIXES = ("_alpine", "_musl")
+
     INTERNAL_REGISTRY_SVC = "image-registry.openshift-image-registry.svc"
 
     def __init__(
@@ -980,6 +993,54 @@ class ImageAnalyzer:
         except Exception:
             return False
 
+    @staticmethod
+    def _looks_like_libc_mismatch(output: str) -> bool:
+        """Return True if *output* looks like a dynamic-linker / libc mismatch."""
+        return any(marker in output for marker in ImageAnalyzer.LIBC_MISMATCH_MARKERS)
+
+    def _infer_node_version_from_sibling(
+        self,
+        unknown_binary: "BinaryInfo",
+        all_binaries: list["BinaryInfo"],
+    ) -> tuple[str, bool | None] | None:
+        """Try to infer the version of an unresolved Node.js binary from a
+        sibling that was successfully resolved.
+
+        The relationship is purely structural: the unresolved binary's
+        container path must contain a directory component ending with a
+        known libc-variant suffix (e.g. ``node20_alpine``), and a sibling
+        binary must exist at the exact same path with that suffix stripped
+        (e.g. ``node20``).
+
+        Returns:
+            ``(version, is_compatible)`` from the resolved sibling, or
+            ``None`` if no sibling match is found.
+        """
+        path = unknown_binary.path
+
+        candidate_paths: set[str] = set()
+        parts = path.split("/")
+        for idx, component in enumerate(parts):
+            for suffix in self.NODE_LIBC_VARIANT_SUFFIXES:
+                if component.endswith(suffix) and component != suffix:
+                    stripped = component[: -len(suffix)]
+                    new_parts = parts.copy()
+                    new_parts[idx] = stripped
+                    candidate_paths.add("/".join(new_parts))
+
+        if not candidate_paths:
+            return None
+
+        for sibling in all_binaries:
+            if sibling is unknown_binary:
+                continue
+            if sibling.version == "unknown":
+                continue
+            if sibling.path in candidate_paths:
+                return sibling.version, sibling.is_compatible
+
+        return None
+
     def _get_dotnet_version_in_container(
         self, image_name: str, binary_path: str, debug: bool = False
     ) -> tuple[str, str]:
@@ -1275,6 +1336,36 @@ class ImageAnalyzer:
                         is_compatible=is_compatible,
                         runtime_type="NodeJS",
                     )
+                )
+
+            # Sibling-lookup fallback for Node.js binaries whose version
+            # could not be resolved by direct execution (typically musl/Alpine
+            # binaries inside a glibc image, or vice versa).
+            for b in result.node_binaries:
+                if b.version != "unknown":
+                    continue
+                if not self._looks_like_libc_mismatch(b.version_output):
+                    continue
+                inferred = self._infer_node_version_from_sibling(b, result.node_binaries)
+                if inferred is None:
+                    continue
+                inferred_version, inferred_compat = inferred
+                logger.debug(
+                    "Node.js: inferred version %s from sibling for %s (libc variant)",
+                    inferred_version,
+                    b.path,
+                )
+                if debug:
+                    print(
+                        f"      [DEBUG] Node.js: inferred {inferred_version} from sibling "
+                        f"for {b.path} (libc variant)"
+                    )
+                b.version = inferred_version
+                b.is_compatible = inferred_compat
+                b.version_output = (
+                    f"{b.version_output}\n"
+                    f"[sibling_inferred] version {inferred_version} propagated from "
+                    f"a resolved sibling binary (libc-variant mismatch)"
                 )
 
             logger.debug("Searching for .NET binaries...")

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -789,3 +789,97 @@ class TestDeepScanResult:
     def test_v2_aware_empty_when_no_matches(self):
         result = ImageAnalysisResult("t", "")
         assert result.deep_scan_v2_aware == ""
+
+
+# ---------------------------------------------------------------------------
+# Node.js sibling-lookup fallback
+# ---------------------------------------------------------------------------
+
+
+class TestNodeSiblingLookup:
+    """Tests for _infer_node_version_from_sibling and its post-pass use."""
+
+    def _make(self, path, version, is_compatible, version_output=""):
+        return BinaryInfo(
+            path=path,
+            version=version,
+            version_output=version_output,
+            is_compatible=is_compatible,
+            runtime_type="NodeJS",
+        )
+
+    def test_alpine_suffix_propagates_from_glibc_sibling(self, analyzer):
+        unknown = self._make(
+            "/home/runner/externals/node20_alpine/bin/node", "unknown", None
+        )
+        glibc = self._make(
+            "/home/runner/externals/node20/bin/node", "20.19.5", True
+        )
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, glibc])
+        assert result == ("20.19.5", True)
+
+    def test_musl_suffix_propagates_from_glibc_sibling(self, analyzer):
+        unknown = self._make("/opt/node24_musl/bin/node", "unknown", None)
+        glibc = self._make("/opt/node24/bin/node", "24.10.0", True)
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, glibc])
+        assert result == ("24.10.0", True)
+
+    def test_no_sibling_returns_none(self, analyzer):
+        unknown = self._make(
+            "/home/runner/externals/node20_alpine/bin/node", "unknown", None
+        )
+        unrelated = self._make("/usr/local/bin/node", "18.19.0", False)
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, unrelated])
+        assert result is None
+
+    def test_sibling_with_unknown_version_is_skipped(self, analyzer):
+        unknown = self._make(
+            "/home/runner/externals/node20_alpine/bin/node", "unknown", None
+        )
+        also_unknown = self._make(
+            "/home/runner/externals/node20/bin/node", "unknown", None
+        )
+        result = analyzer._infer_node_version_from_sibling(
+            unknown, [unknown, also_unknown]
+        )
+        assert result is None
+
+    def test_no_libc_variant_suffix_returns_none(self, analyzer):
+        unknown = self._make("/usr/local/bin/node", "unknown", None)
+        other = self._make("/opt/node/bin/node", "20.19.5", True)
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, other])
+        assert result is None
+
+    def test_incompatible_sibling_propagates_incompatibility(self, analyzer):
+        unknown = self._make(
+            "/home/runner/externals/node18_alpine/bin/node", "unknown", None
+        )
+        glibc = self._make(
+            "/home/runner/externals/node18/bin/node", "18.19.0", False
+        )
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, glibc])
+        assert result == ("18.19.0", False)
+
+    def test_libc_mismatch_marker_detected(self, analyzer):
+        output = (
+            '{"msg":"exec container process (missing dynamic library?) '
+            "`/home/runner/externals/node20_alpine/bin/node`: No such file or "
+            'directory","level":"error"}'
+        )
+        assert analyzer._looks_like_libc_mismatch(output) is True
+
+    def test_libc_mismatch_marker_absent(self, analyzer):
+        assert analyzer._looks_like_libc_mismatch("Command timed out") is False
+        assert analyzer._looks_like_libc_mismatch("") is False
+        assert (
+            analyzer._looks_like_libc_mismatch(
+                "some unrelated error: No such file or directory"
+            )
+            is False
+        )
+
+    def test_does_not_match_bare_suffix_component(self, analyzer):
+        unknown = self._make("/_alpine/bin/node", "unknown", None)
+        other = self._make("//bin/node", "20.19.5", True)
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, other])
+        assert result is None

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -809,12 +809,8 @@ class TestNodeSiblingLookup:
         )
 
     def test_alpine_suffix_propagates_from_glibc_sibling(self, analyzer):
-        unknown = self._make(
-            "/home/runner/externals/node20_alpine/bin/node", "unknown", None
-        )
-        glibc = self._make(
-            "/home/runner/externals/node20/bin/node", "20.19.5", True
-        )
+        unknown = self._make("/home/runner/externals/node20_alpine/bin/node", "unknown", None)
+        glibc = self._make("/home/runner/externals/node20/bin/node", "20.19.5", True)
         result = analyzer._infer_node_version_from_sibling(unknown, [unknown, glibc])
         assert result == ("20.19.5", True)
 
@@ -825,23 +821,15 @@ class TestNodeSiblingLookup:
         assert result == ("24.10.0", True)
 
     def test_no_sibling_returns_none(self, analyzer):
-        unknown = self._make(
-            "/home/runner/externals/node20_alpine/bin/node", "unknown", None
-        )
+        unknown = self._make("/home/runner/externals/node20_alpine/bin/node", "unknown", None)
         unrelated = self._make("/usr/local/bin/node", "18.19.0", False)
         result = analyzer._infer_node_version_from_sibling(unknown, [unknown, unrelated])
         assert result is None
 
     def test_sibling_with_unknown_version_is_skipped(self, analyzer):
-        unknown = self._make(
-            "/home/runner/externals/node20_alpine/bin/node", "unknown", None
-        )
-        also_unknown = self._make(
-            "/home/runner/externals/node20/bin/node", "unknown", None
-        )
-        result = analyzer._infer_node_version_from_sibling(
-            unknown, [unknown, also_unknown]
-        )
+        unknown = self._make("/home/runner/externals/node20_alpine/bin/node", "unknown", None)
+        also_unknown = self._make("/home/runner/externals/node20/bin/node", "unknown", None)
+        result = analyzer._infer_node_version_from_sibling(unknown, [unknown, also_unknown])
         assert result is None
 
     def test_no_libc_variant_suffix_returns_none(self, analyzer):
@@ -851,12 +839,8 @@ class TestNodeSiblingLookup:
         assert result is None
 
     def test_incompatible_sibling_propagates_incompatibility(self, analyzer):
-        unknown = self._make(
-            "/home/runner/externals/node18_alpine/bin/node", "unknown", None
-        )
-        glibc = self._make(
-            "/home/runner/externals/node18/bin/node", "18.19.0", False
-        )
+        unknown = self._make("/home/runner/externals/node18_alpine/bin/node", "unknown", None)
+        glibc = self._make("/home/runner/externals/node18/bin/node", "18.19.0", False)
         result = analyzer._infer_node_version_from_sibling(unknown, [unknown, glibc])
         assert result == ("18.19.0", False)
 
@@ -871,12 +855,7 @@ class TestNodeSiblingLookup:
     def test_libc_mismatch_marker_absent(self, analyzer):
         assert analyzer._looks_like_libc_mismatch("Command timed out") is False
         assert analyzer._looks_like_libc_mismatch("") is False
-        assert (
-            analyzer._looks_like_libc_mismatch(
-                "some unrelated error: No such file or directory"
-            )
-            is False
-        )
+        assert analyzer._looks_like_libc_mismatch("some unrelated error: No such file or directory") is False
 
     def test_does_not_match_bare_suffix_component(self, analyzer):
         unknown = self._make("/_alpine/bin/node", "unknown", None)


### PR DESCRIPTION
When a nodeXX_alpine or nodeXX_musl binary fails to execute due to a libc mismatch (e.g. inside a glibc-based image), infer its version from the paired glibc sibling at the same installation path. This resolves "Unknown" cgroup v2 compatibility verdicts for GitHub Actions Runner images that ship both variants side-by-side.