### PR TITLE
chore: align in-repo version to v2.4 and introduce single source of t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.5.0] — Unreleased
+## [2.5.0] — 2026-05-18
 
 ### Added
 - **HTML report** alongside the CSV output (#62): new `--html-report`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.5.0] — Unreleased
+
+### Changed
+- Align in-repo version to actual release tags and introduce a single
+  source of truth (`src/__init__.py:__version__`); `pyproject.toml` and
+  the main script now read from it. `--version` and the ASCII banner
+  now report the real release version instead of the stale `2.0.0`
+  literal that was never released.
+- Backfill `CHANGELOG.md` entries for `[2.1.0]` through `[2.4.0]` from
+  git history (these releases shipped without changelog updates).
+
+### Added
+- `tests/test_version.py` smoke tests guarding against future drift
+  between `src/__init__.py:__version__`, `pyproject.toml`, and the main
+  script's import.
+
 ## [2.4.0] — 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## [2.5.0] — Unreleased
 
+### Added
+- **HTML report** alongside the CSV output (#62): new `--html-report`
+  flag generates a self-contained HTML report (DataTables + Jinja2,
+  assets bundled for air-gapped environments) under
+  `<output-dir>/html/<basename>.html`. New `--report-only <CSV>` flag
+  regenerates the HTML offline from an existing CSV without re-scanning.
+  Includes interactive pie chart, clickable status cards, per-runtime
+  drill-down filters, and a removable filter banner. Adds
+  `not_applicable` overall-status to replace the misleading `unknown`
+  fallthrough for images with no detected runtime.
+- **Deterministic Go binary cgroups v2 scanning** (#60): replaces the
+  heuristic `strings`+`grep` approach with precise `go version` /
+  `go version -m` analysis. Go ≥ 1.19 is natively compatible; older
+  versions are checked against a v2-aware module matrix
+  (`automaxprocs`, `automemlimit`, …). New `--disable-go` CLI flag and
+  four new CSV columns (`go_binary`, `go_version`,
+  `go_cgroup_v2_compatible`, `go_modules`); the deprecated
+  `deep_scan_go_cgroup_libs` column is removed.
+- **Node.js sibling-lookup fallback** for musl/Alpine binaries (#61):
+  when a `nodeXX_alpine` / `nodeXX_musl` binary fails to execute due to
+  a libc / dynamic-linker mismatch (e.g. GitHub Actions Runner images
+  shipping both glibc and musl builds side-by-side), the version is now
+  inferred from the paired glibc sibling at the same installation path,
+  turning previously "Unknown" rows into deterministic Yes/No verdicts.
+- Quay infrastructure for Go cgroups v2 compliance test images (#59):
+  seven new deep-scan fixture images under
+  `manifests/quay/deep-scan-images/go-v2-*/` covering compliant,
+  needs-review, and unaware runtime/library combinations.
+- `tests/test_version.py` smoke tests guarding against future drift
+  between `src/__init__.py:__version__`, `pyproject.toml`, and the main
+  script's import.
+
 ### Changed
 - Align in-repo version to actual release tags and introduce a single
   source of truth (`src/__init__.py:__version__`); `pyproject.toml` and
@@ -12,11 +44,6 @@ All notable changes to this project will be documented in this file.
   literal that was never released.
 - Backfill `CHANGELOG.md` entries for `[2.1.0]` through `[2.4.0]` from
   git history (these releases shipped without changelog updates).
-
-### Added
-- `tests/test_version.py` smoke tests guarding against future drift
-  between `src/__init__.py:__version__`, `pyproject.toml`, and the main
-  script's import.
 
 ## [2.4.0] — 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0] — Unreleased
+## [2.4.0] — 2026-04-14
+
+### Added
+- Detect Go cgroup library imports in binary deep-scan (#56)
+- Follow `exec` chains from entrypoint scripts to ELF binaries for deep-scan
+- Pre-flight check for `strings` binary when `--deep-scan` is enabled (#54)
+
+### Changed
+- Propagate verbose debug logging to log file (#57)
+
+## [2.3.0] — 2026-04-13
+
+### Added
+- Deep-scan heuristic mode for cgroup v1 references in entrypoint scripts and binaries (#51)
+
+### Changed
+- Move `analysis_error` to last CSV column (#53)
+
+## [2.2.0] — 2026-04-11
+
+### Added
+- `--resume` flag to allow restarting interrupted scans (#43, #45)
+- `--image-timeout` flag for per-image pull+scan deadline (#42, #44)
+
+## [2.1.0] — 2026-04-10
+
+### Changed
+- Handle unknown runtime versions: return "Unknown" compatibility instead of "No" (#40)
+- Exclude `node_modules` from binary scan and add "Unknown" count to summary recap (#41)
+
+## [2.0.0] — 2026-04-03
 
 ### Added
 - **Quay registry scan mode**: scan container images directly from a
@@ -38,7 +68,6 @@ All notable changes to this project will be documented in this file.
   `AnalysisOrchestrator` (shared by both modes)
 - CSV output now includes 3 additional columns (`source`,
   `registry_org`, `registry_repo`) — backward compatible
-- Version bumped to 2.0.0
 - GitHub Actions CI updated to run on feature branches
 - OpenShift test manifests moved from `test/` to `manifests/cluster/`
 - Docker/container support added (Containerfile by @beelzetron)

--- a/README.md
+++ b/README.md
@@ -1046,7 +1046,7 @@ The setup script is idempotent and includes retry logic (3 attempts) for push op
 
 ```
 image-cgroupsv2-inspector/
-├── image-cgroupsv2-inspector   # Main executable (Python 3.12) — v2.0.0
+├── image-cgroupsv2-inspector   # Main executable (Python 3.12)
 ├── requirements.txt
 ├── pyproject.toml              # ruff + pytest config
 ├── Containerfile

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -28,6 +28,7 @@ from pathlib import Path
 script_dir = Path(__file__).parent.resolve()
 sys.path.insert(0, str(script_dir))
 
+from src import __version__ as TOOL_VERSION
 from src.analysis_orchestrator import AnalysisOrchestrator
 from src.auth_utils import generate_registry_auth_json
 from src.html_reporter import generate_html_report
@@ -38,8 +39,6 @@ from src.registry_collector import RegistryCollector
 from src.rootfs_manager import RootFSManager
 from src.scan_state import ScanState
 from src.system_checks import run_system_checks
-
-TOOL_VERSION = "2.0.0"
 
 logger = logging.getLogger("image-cgroupsv2-inspector")
 
@@ -396,9 +395,10 @@ def setup_logging(log_to_file: bool, log_file: str, verbose: bool) -> logging.Lo
 
 def print_banner():
     """Print the application banner."""
-    banner = """
+    version_label = f"v{TOOL_VERSION}".ljust(10)
+    banner = f"""
 ╔══════════════════════════════════════════════════════════════╗
-║           image-cgroupsv2-inspector v2.0.0                   ║
+║           image-cgroupsv2-inspector {version_label}               ║
 ║  Container Image Inspector for cgroups v2 Compatibility      ║
 ║  Supports: OpenShift cluster scan | Quay registry scan       ║
 ╚══════════════════════════════════════════════════════════════╝

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "image-cgroupsv2-inspector"
 # Keep in sync with src/__init__.py:__version__
-version = "2.4.0"
+version = "2.5.0"
 requires-python = ">=3.12"
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "image-cgroupsv2-inspector"
-version = "1.0.0"
+# Keep in sync with src/__init__.py:__version__
+version = "2.4.0"
 requires-python = ">=3.12"
 
 [tool.ruff]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,7 @@
 # image-cgroupsv2-inspector
 # OpenShift container image inspector for cgroups v2 compatibility
 
+# Single source of truth for the tool version.
+# Convention: git tag `vX.Y` maps to `"X.Y.0"`. Hotfixes use `vX.Y.Z` ↔ `"X.Y.Z"`.
+# When bumping, update this AND `pyproject.toml` to the same value.
+__version__ = "2.4.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,4 +4,4 @@
 # Single source of truth for the tool version.
 # Convention: git tag `vX.Y` maps to `"X.Y.0"`. Hotfixes use `vX.Y.Z` ↔ `"X.Y.Z"`.
 # When bumping, update this AND `pyproject.toml` to the same value.
-__version__ = "2.4.0"
+__version__ = "2.5.0"

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -106,11 +106,13 @@ class TestParseArguments:
             args = parse_arguments()
         assert args.latest_only == 5
 
-    def test_version_is_2(self, capsys):
+    def test_version_is_current(self, capsys):
+        from src import __version__
+
         with patch("sys.argv", ["image-cgroupsv2-inspector", "--version"]), pytest.raises(SystemExit):
             parse_arguments()
         captured = capsys.readouterr()
-        assert "2.0.0" in captured.out
+        assert __version__ in captured.out
 
     def test_openshift_args_still_work(self):
         with patch(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the tool version single source of truth."""
+
+import re
+import tomllib
+from pathlib import Path
+
+from src import __version__
+
+# PEP 440-ish: X.Y.Z with optional pre/post/dev suffix tolerated.
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+].+)?$")
+
+
+def test_version_is_well_formed():
+    """__version__ must follow X.Y.Z."""
+    assert _VERSION_RE.match(__version__), f"__version__={__version__!r} does not match X.Y.Z"
+
+
+def test_pyproject_version_matches_sot():
+    """pyproject.toml `version` must equal src.__version__."""
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    assert pyproject["project"]["version"] == __version__, (
+        f"pyproject.toml version ({pyproject['project']['version']!r}) "
+        f"is out of sync with src.__version__ ({__version__!r}). "
+        "Update both together."
+    )
+
+
+def test_main_script_uses_sot():
+    """The main script must import TOOL_VERSION from src, not hardcode it."""
+    main = Path("image-cgroupsv2-inspector").read_text()
+    assert "from src import __version__ as TOOL_VERSION" in main, (
+        "Main script must import TOOL_VERSION from src.__version__ (single SoT)."
+    )
+    assert 'TOOL_VERSION = "' not in main, "Main script should not redefine TOOL_VERSION as a literal."


### PR DESCRIPTION
…ruth

Move the canonical version string to src/__init__.py (`__version__ = "2.4.0"`) and have pyproject.toml and the main script import from it, so future bumps only require updating two lines.
- src/__init__.py: add __version__ as SoT
- pyproject.toml: bump 1.0.0 → 2.4.0, add sync comment
- image-cgroupsv2-inspector: import TOOL_VERSION from SoT, replace hardcoded banner with padded f-string
- README.md: drop version suffix from project-structure tree
- CHANGELOG.md: close [2.0.0], backfill [2.1.0]–[2.4.0] from git log
- tests/test_version.py: add smoke tests for version format, pyproject sync, and SoT import
- tests/test_cli_registry.py: assert --version output against SoT instead of hardcoded "2.0.0"