### PR TITLE
fix(ci): add missing pytest step to test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
           pip install -r requirements.txt
           pip install pytest pytest-cov
 
+      - name: Run tests
+        run: pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
+
       - name: Upload coverage report
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- CI `test` job now actually runs `pytest`. The job installed
+  `pytest`/`pytest-cov` and uploaded `coverage.xml` but never invoked
+  the test runner, so the suite had been silently skipped in CI. The
+  new `Run tests` step executes `pytest tests/ -v --cov=src
+  --cov-report=xml --cov-report=term` and produces the coverage report
+  referenced by the existing upload step.
+
 ## [2.5.0] — 2026-05-18
 
 ### Added


### PR DESCRIPTION
The test job installed pytest and pytest-cov and uploaded coverage.xml, but never actually invoked the test runner — silently skipping the entire suite. Add a "Run tests" step that runs
`pytest tests/ -v --cov=src --cov-report=xml --cov-report=term` so failures break CI and the upload step has a report to upload.