### PR TITLE
honour proxy env vars in kubernetes client

### DIFF
--- a/src/openshift_client.py
+++ b/src/openshift_client.py
@@ -107,6 +107,25 @@ class OpenShiftClient:
         configuration.api_key = {"authorization": f"Bearer {self.token}"}
         configuration.verify_ssl = self.verify_ssl
 
+        # Honour NO_PROXY / no_proxy env vars for the kubernetes client.
+        # The kubernetes Python library uses urllib3 directly and does not
+        # automatically respect the standard proxy env vars, so we read them
+        # here and set them explicitly on the Configuration object.
+        _no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
+        _proxy    = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy") or                     os.environ.get("HTTP_PROXY")  or os.environ.get("http_proxy")  or ""
+        if _no_proxy:
+            configuration.no_proxy = _no_proxy
+        if _proxy:
+            from urllib.parse import urlparse as _urlparse
+            _parsed = _urlparse(self.api_url)
+            _host   = _parsed.hostname or ""
+            _bypass = any(
+                _host == e.strip().lstrip(".") or _host.endswith("." + e.strip().lstrip("."))
+                for e in _no_proxy.split(",") if e.strip()
+            )
+            if not _bypass:
+                configuration.proxy = _proxy
+
         # Create API client
         self._api_client = ApiClient(configuration)
 


### PR DESCRIPTION
The Python kubernetes library uses urllib3 directly and does not automatically read the standard proxy environment variables (HTTPS_PROXY, NO_PROXY, etc.), unlike curl or requests.

This caused a 504 Gateway Timeout when running inside a container in a proxied environment, even with NO_PROXY correctly set.

Fix: explicitly read proxy env vars and set them on the Configuration object in openshift_client.py. The OpenShift API host is connected directly if it matches NO_PROXY; the proxy is used only for everything else. Both uppercase and lowercase variants are supported.