### PR TITLE
chore(openshift): tidy proxy env-var handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to this project will be documented in this file.
   new `Run tests` step executes `pytest tests/ -v --cov=src
   --cov-report=xml --cov-report=term` and produces the coverage report
   referenced by the existing upload step.
+- Proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` and lowercase
+  variants) are now honoured by the OpenShift API client (#67). The
+  underlying `kubernetes` library uses `urllib3` directly and does not
+  read these env vars automatically, which caused 504 Gateway Timeout
+  in proxied containerised deployments. The API host is reached
+  directly when its hostname matches `NO_PROXY` (exact or `.suffix`
+  match) and via the proxy otherwise.
 
 ## [2.5.0] — 2026-05-18
 

--- a/src/openshift_client.py
+++ b/src/openshift_client.py
@@ -112,16 +112,21 @@ class OpenShiftClient:
         # automatically respect the standard proxy env vars, so we read them
         # here and set them explicitly on the Configuration object.
         _no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
-        _proxy    = os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy") or                     os.environ.get("HTTP_PROXY")  or os.environ.get("http_proxy")  or ""
+        _proxy = (
+            os.environ.get("HTTPS_PROXY")
+            or os.environ.get("https_proxy")
+            or os.environ.get("HTTP_PROXY")
+            or os.environ.get("http_proxy")
+            or ""
+        )
         if _no_proxy:
             configuration.no_proxy = _no_proxy
         if _proxy:
-            from urllib.parse import urlparse as _urlparse
-            _parsed = _urlparse(self.api_url)
-            _host   = _parsed.hostname or ""
+            _host = urlparse(self.api_url).hostname or ""
             _bypass = any(
                 _host == e.strip().lstrip(".") or _host.endswith("." + e.strip().lstrip("."))
-                for e in _no_proxy.split(",") if e.strip()
+                for e in _no_proxy.split(",")
+                if e.strip()
             )
             if not _bypass:
                 configuration.proxy = _proxy


### PR DESCRIPTION
Follow-up to #67. Pure cleanup, no behavior change.

- Drop the redundant inline `from urllib.parse import urlparse as _urlparse` — `urlparse` was already imported at module top (`src/openshift_client.py:11`).
- Apply `ruff format` to the proxy block (the original multi-space alignment would have failed CI's `ruff format --check`).
- Add a `CHANGELOG.md` entry under `[Unreleased] > Fixed` describing the proxy-env-var fix.

## Test plan
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean (31 files already formatted)
- [x] `pytest tests/ -v` → 564 passed