### PR TITLE
Fix OpenShift token authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ All notable changes to this project will be documented in this file.
   new `Run tests` step executes `pytest tests/ -v --cov=src
   --cov-report=xml --cov-report=term` and produces the coverage report
   referenced by the existing upload step.
+- OpenShift mode now configures bearer-token auth the way the Python
+  Kubernetes client expects, so valid `--token` values are no longer
+  dropped on protected API calls. `connect()` also performs an
+  authenticated OpenShift API check instead of treating the unauthenticated
+  `/version` probe as sufficient.
 - Proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` and lowercase
   variants) are now honoured by the OpenShift API client (#67). The
   underlying `kubernetes` library uses `urllib3` directly and does not

--- a/src/openshift_client.py
+++ b/src/openshift_client.py
@@ -104,7 +104,8 @@ class OpenShiftClient:
         # Configure the client
         configuration = Configuration()
         configuration.host = self.api_url
-        configuration.api_key = {"authorization": f"Bearer {self.token}"}
+        configuration.api_key = {"BearerToken": self.token}
+        configuration.api_key_prefix = {"BearerToken": "Bearer"}
         configuration.verify_ssl = self.verify_ssl
 
         # Honour NO_PROXY / no_proxy env vars for the kubernetes client.
@@ -138,8 +139,10 @@ class OpenShiftClient:
         try:
             version_api = client.VersionApi(self._api_client)
             version_info = version_api.get_code()
+            username = self._get_authenticated_username()
             logger.debug("Connected to OpenShift cluster")
             logger.debug("Kubernetes version: %s", version_info.git_version)
+            logger.debug("Authenticated OpenShift user: %s", username)
             print("✓ Connected to OpenShift cluster")
             print(f"  Kubernetes version: {version_info.git_version}")
 
@@ -155,6 +158,27 @@ class OpenShiftClient:
         except Exception as e:
             self._api_client = None
             raise Exception(f"Failed to connect to OpenShift cluster: {e}")
+
+    def _get_authenticated_username(self) -> str:
+        """Return the current authenticated OpenShift username."""
+        try:
+            user = self.get_custom_objects_api().get_cluster_custom_object(
+                group="user.openshift.io",
+                version="v1",
+                plural="users",
+                name="~",
+            )
+        except ApiException as e:
+            if e.status in (401, 403):
+                raise RuntimeError(
+                    f"token was not accepted for authenticated OpenShift API access ({e.status} {e.reason})"
+                ) from e
+            raise
+
+        username = user.get("metadata", {}).get("name", "")
+        if not username:
+            raise RuntimeError("authenticated OpenShift user lookup returned no metadata.name")
+        return username
 
     def _save_to_env(self) -> None:
         """Save API URL and token to .env file."""

--- a/tests/test_openshift_client.py
+++ b/tests/test_openshift_client.py
@@ -1,4 +1,10 @@
-"""Tests for the OpenShiftClient module — cluster name extraction."""
+"""Tests for the OpenShiftClient module."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kubernetes.client.rest import ApiException
 
 from src.openshift_client import OpenShiftClient
 
@@ -46,3 +52,65 @@ class TestClusterNameExtraction:
     def test_api_url_complex_domain(self):
         client = self._make_client("https://api.shrocp4upi417ovn.lab.upshift.rdu2.redhat.com:6443")
         assert client._extract_cluster_name() == "shrocp4upi417ovn.lab.upshift.rdu2.redhat.com"
+
+
+class TestConnect:
+    """Tests for OpenShift client connection/authentication setup."""
+
+    def _make_client(self, tmp_path, token="fake-token"):
+        return OpenShiftClient(
+            api_url="https://api.mycluster.example.com:6443",
+            token=token,
+            env_file=str(tmp_path / ".env"),
+            pull_secret_file=str(tmp_path / ".pull-secret"),
+        )
+
+    def test_connect_configures_bearer_token_auth(self, tmp_path):
+        client = self._make_client(tmp_path)
+        captured = {}
+        api_client = MagicMock()
+
+        def build_api_client(configuration):
+            captured["configuration"] = configuration
+            return api_client
+
+        with (
+            patch("src.openshift_client.ApiClient", side_effect=build_api_client),
+            patch("src.openshift_client.client.VersionApi") as mock_version_api,
+            patch("src.openshift_client.client.CustomObjectsApi") as mock_custom_objects_api,
+            patch.object(OpenShiftClient, "_save_to_env"),
+            patch.object(OpenShiftClient, "_download_pull_secret"),
+        ):
+            mock_version_api.return_value.get_code.return_value = SimpleNamespace(git_version="v1.28.2")
+            mock_custom_objects_api.return_value.get_cluster_custom_object.return_value = {
+                "metadata": {"name": "alice"}
+            }
+
+            assert client.connect() is True
+
+        configuration = captured["configuration"]
+        assert configuration.api_key == {"BearerToken": "fake-token"}
+        assert configuration.api_key_prefix == {"BearerToken": "Bearer"}
+        assert client.api_client is api_client
+
+    def test_connect_fails_when_authenticated_probe_is_forbidden(self, tmp_path):
+        client = self._make_client(tmp_path)
+
+        with (
+            patch("src.openshift_client.ApiClient", return_value=MagicMock()),
+            patch("src.openshift_client.client.VersionApi") as mock_version_api,
+            patch("src.openshift_client.client.CustomObjectsApi") as mock_custom_objects_api,
+            patch.object(OpenShiftClient, "_save_to_env") as mock_save_to_env,
+            patch.object(OpenShiftClient, "_download_pull_secret") as mock_download_pull_secret,
+        ):
+            mock_version_api.return_value.get_code.return_value = SimpleNamespace(git_version="v1.28.2")
+            mock_custom_objects_api.return_value.get_cluster_custom_object.side_effect = ApiException(
+                status=403, reason="Forbidden"
+            )
+
+            with pytest.raises(Exception, match="token was not accepted for authenticated OpenShift API access"):
+                client.connect()
+
+        mock_save_to_env.assert_not_called()
+        mock_download_pull_secret.assert_not_called()
+        assert client._api_client is None


### PR DESCRIPTION
When using the token, the scanner got 403 Forbidden as User "system:anonymous" when listing pods,deployments, etc., and ended up finding 0 containers.

 - Root cause: in src/openshift_client.py, the client set the token under the wrong config key. The installed KubernetesPython client only injects the Authorization: Bearer ... header when auth is configured as BearerToken, not via the genericauthorization entry the code was using.
 - Why it looked connected anyway: connect() only checked the cluster /version endpoint first. That endpoint can succeed even when authenticated resource access is broken, so the tool printed “Connected to OpenShift cluster” even though laternamespace queries were effectively anonymous.
 - Fix: use the Kubernetes Python client's BearerToken auth configuration so valid --token values are sent on protected API calls, and require an authenticated OpenShift probe during connect() to avoid false-positive cluster connections. 
 
 Also regression tests have been added.