### PR TITLE
fix(container): patch base packages and slim image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
   same layer to keep the image smaller.
 
 ### Added
+- README: document the prebuilt images published on Quay.io
+  (`quay.io/asalvati/image-cgroupsv2-inspector`) with a `podman pull` example.
 - CI: release workflow (`release.yml`) builds standalone binaries for
   Linux/macOS × amd64/arm64 using native runners (ARM runner for ARM
   builds), and pushes multi-arch container image to `ghcr.io`. ARM64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- Containerfile now runs `dnf update` during build so base-image packages are
+  patched to the latest errata, clearing fixable OS-package CVEs.
+
+### Changed
+- Containerfile installs with `tsflags=nodocs` and clears the dnf cache in the
+  same layer to keep the image smaller.
+
 ### Added
 - CI: release workflow (`release.yml`) builds standalone binaries for
   Linux/macOS × amd64/arm64 using native runners (ARM runner for ARM

--- a/Containerfile
+++ b/Containerfile
@@ -3,9 +3,17 @@
 FROM registry.access.redhat.com/ubi9/python-312
 
 USER root
-# Install system dependencies: podman (image pull/inspect), acl (extended ACLs for rootfs),
-# golang (deterministic Go binary scanning via `go version`)
-RUN dnf install -y podman acl golang && dnf clean all
+# Patch base-image packages (security), then install system dependencies:
+# podman (image pull/inspect), acl (extended ACLs for rootfs), golang
+# (deterministic Go binary scanning via `go version`). Skip docs/man pages and
+# clear the dnf cache in the same layer to keep the image small.
+# NOTE: weak deps are intentionally kept — rootless podman relies on helpers
+# (crun, netavark, aardvark-dns, fuse-overlayfs, slirp4netns/pasta) that ship
+# as weak deps on UBI 9; dropping them would break in-container `podman pull`.
+RUN dnf -y update --setopt=tsflags=nodocs && \
+    dnf -y install --setopt=tsflags=nodocs podman acl golang && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ pip install -r requirements.txt
 
 You can build and run the tool as a container (UBI 9, Python 3.12). The image includes `podman`, `acl`, and `golang`, so Go binary scanning is enabled by default. The image uses the main script as the entrypoint.
 
+**Pull (prebuilt image):**
+
+Prebuilt images are published to Quay.io at
+[quay.io/asalvati/image-cgroupsv2-inspector](https://quay.io/repository/asalvati/image-cgroupsv2-inspector):
+
+```bash
+podman pull quay.io/asalvati/image-cgroupsv2-inspector:latest
+# or: docker pull quay.io/asalvati/image-cgroupsv2-inspector:latest
+```
+
 **Build:**
 
 ```bash


### PR DESCRIPTION
Run `dnf update` during build so UBI 9 base-image packages are patched to the latest errata, clearing the fixable OS-package CVEs (e.g. rsync CVE-2026-43618 / CVE-2026-29518) reported by the Quay scanner. Install with `tsflags=nodocs` and clear the dnf cache in the same layer to keep the image small; weak deps are kept so rootless podman still works.