### PR TITLE
fix(security): harden rootfs containment check and cleanup post-PR#73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ All notable changes to this project will be documented in this file.
   `source == "registry"`.
 
 ### Fixed
+- Rootfs containment check in `_resolve_script_in_rootfs` now uses a
+  trailing `os.sep` in the prefix comparison, closing a string-prefix
+  collision where a sibling directory sharing the rootfs name (e.g.
+  `rootfs-evil` vs `rootfs`) could bypass the boundary check.
 - Go scanner and deep scan now detect bare commands (e.g. `exec grafana
   server`) in entrypoint scripts by searching standard PATH directories
   inside the extracted rootfs, including non-standard directories from

--- a/src/deep_scan.py
+++ b/src/deep_scan.py
@@ -15,6 +15,7 @@ Confidence levels:
 from __future__ import annotations
 
 import logging
+import os
 import re
 from pathlib import Path
 
@@ -180,7 +181,7 @@ _SET_PATTERN = re.compile(
     re.MULTILINE,
 )
 
-_DEFAULT_PATH_DIRS = (
+DEFAULT_PATH_DIRS = (
     "usr/local/sbin",
     "usr/local/bin",
     "usr/sbin",
@@ -227,6 +228,12 @@ def _is_shell_script(file_path: Path) -> bool:
         return False
 
 
+def _is_within_rootfs(resolved: Path, extract_path: Path) -> bool:
+    """Return True if *resolved* is strictly inside *extract_path*."""
+    prefix = str(extract_path.resolve()) + os.sep
+    return str(resolved).startswith(prefix)
+
+
 def _resolve_script_in_rootfs(
     script_ref: str,
     extract_path: Path,
@@ -238,7 +245,7 @@ def _resolve_script_in_rootfs(
     Handles:
     - Absolute paths: /usr/local/bin/entrypoint.sh
     - Relative paths: ./helpers.sh (resolved relative to `relative_to`)
-    - Bare commands: searched in _DEFAULT_PATH_DIRS + extra_path_dirs
+    - Bare commands: searched in DEFAULT_PATH_DIRS + extra_path_dirs
     - Shell variable paths: ${SCRIPT_DIR}/helpers.sh, $DIR/helpers.sh
       → extracts the filename and tries relative resolution against
         the directory of the sourcing script
@@ -260,7 +267,7 @@ def _resolve_script_in_rootfs(
                 candidate = relative_to / filename
                 try:
                     resolved = candidate.resolve()
-                    if str(resolved).startswith(str(extract_path.resolve())) and resolved.is_file():
+                    if _is_within_rootfs(resolved, extract_path) and resolved.is_file():
                         return resolved
                 except (OSError, ValueError):
                     pass
@@ -272,18 +279,18 @@ def _resolve_script_in_rootfs(
             candidate = relative_to / script_ref
             try:
                 resolved = candidate.resolve()
-                if str(resolved).startswith(str(extract_path.resolve())) and resolved.is_file():
+                if _is_within_rootfs(resolved, extract_path) and resolved.is_file():
                     return resolved
             except (OSError, ValueError):
                 pass
-        search_dirs = _DEFAULT_PATH_DIRS
+        search_dirs = DEFAULT_PATH_DIRS
         if extra_path_dirs:
-            search_dirs = extra_path_dirs + _DEFAULT_PATH_DIRS
+            search_dirs = extra_path_dirs + DEFAULT_PATH_DIRS
         for path_dir in search_dirs:
             candidate = extract_path / path_dir / script_ref
             try:
                 resolved = candidate.resolve()
-                if str(resolved).startswith(str(extract_path.resolve())) and resolved.is_file():
+                if _is_within_rootfs(resolved, extract_path) and resolved.is_file():
                     return resolved
             except (OSError, ValueError):
                 continue
@@ -296,7 +303,7 @@ def _resolve_script_in_rootfs(
 
     try:
         resolved = candidate.resolve()
-        if not str(resolved).startswith(str(extract_path.resolve())):
+        if not _is_within_rootfs(resolved, extract_path):
             return None
         if resolved.is_file():
             return resolved

--- a/src/image_analyzer.py
+++ b/src/image_analyzer.py
@@ -12,6 +12,7 @@ Supported runtimes and minimum versions for cgroup v2:
 """
 
 import contextlib
+import json
 import logging
 import os
 import re
@@ -484,9 +485,7 @@ class ImageAnalyzer:
         Returns:
             Tuple of extra directory strings (relative to rootfs), or None.
         """
-        import json
-
-        from .deep_scan import _DEFAULT_PATH_DIRS
+        from .deep_scan import DEFAULT_PATH_DIRS
 
         exit_code, stdout, _stderr = self._run_command(
             ["podman", "inspect", "--format", "{{json .Config.Env}}", image_name],
@@ -501,7 +500,7 @@ class ImageAnalyzer:
         except (json.JSONDecodeError, TypeError):
             return None
 
-        default_set = set(_DEFAULT_PATH_DIRS)
+        default_set = set(DEFAULT_PATH_DIRS)
         for env_var in env_list or []:
             if env_var.startswith("PATH="):
                 dirs = env_var[5:].split(":")

--- a/tests/test_deep_scan.py
+++ b/tests/test_deep_scan.py
@@ -374,6 +374,19 @@ class TestResolveScriptInRootfs:
         result = _resolve_script_in_rootfs("${DIR}/../../etc/passwd", tmp_path, relative_to=parent)
         assert result is None
 
+    def test_prefix_collision_blocked(self, tmp_path):
+        """A sibling dir sharing the rootfs name prefix must not be resolved."""
+        rootfs = tmp_path / "rootfs"
+        rootfs.mkdir()
+        evil = tmp_path / "rootfs-evil" / "usr" / "bin"
+        evil.mkdir(parents=True)
+        script = evil / "pwned.sh"
+        script.write_text("#!/bin/bash\necho pwned")
+        symlink = rootfs / "link.sh"
+        symlink.symlink_to(script)
+        result = _resolve_script_in_rootfs("/link.sh", rootfs)
+        assert result is None
+
 
 class TestScanEntrypointScripts:
     """Integration tests for scan_entrypoint_scripts()."""


### PR DESCRIPTION
Close string-prefix collision in _resolve_script_in_rootfs where a sibling directory sharing the extract_path prefix (e.g. rootfs-evil vs rootfs) could bypass the boundary check.  Extract _is_within_rootfs helper using trailing os.sep, matching the pattern already used by _symlink_stays_in_rootfs.  Also rename _DEFAULT_PATH_DIRS to public and move inline import json to top-level in image_analyzer.py.