### PR TITLE
fix: post-PR#76 cleanup — remove RHEL 8 support, fix changelog, impro…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,3 @@ jobs:
             --hidden-import=src \
             image-cgroupsv2-inspector
           ./dist/image-cgroupsv2-inspector-linux-amd64 --help
-
-  binary-build-check-el8:
-    runs-on: ubuntu-latest
-    needs: lint-test
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Verify PyInstaller build (RHEL 8 / glibc 2.28)
-        run: |
-          docker run --rm -v "$PWD:/work" -w /work registry.access.redhat.com/ubi8/ubi:8.10 bash -c "
-            set -euo pipefail
-            dnf -y install python3.12 python3.12-pip gcc python3.12-devel
-            python3.12 -m pip install --upgrade pip
-            python3.12 -m pip install -r requirements.txt pyinstaller
-            python3.12 -m PyInstaller --onefile --name image-cgroupsv2-inspector-linux-amd64-el8 \
-              --add-data 'src:src' \
-              --hidden-import=src \
-              image-cgroupsv2-inspector
-          "
-          ./dist/image-cgroupsv2-inspector-linux-amd64-el8 --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
   # ───────────────────────────────────────────────────────────────────
   # Binary builds — native runners for each arch (no emulation overhead)
   #
-  # linux-amd64-el8 is built inside UBI 8 (glibc 2.28) so it runs on RHEL 8;
-  # the default linux-amd64 artifact from ubuntu-latest needs GLIBC_2.38+.
-  #
   # NOTE: ARM64 binaries and containers are provided for ARM-native hosts
   # only. The tool does not support cross-architecture scanning: podman
   # pull fetches the host's native arch, and runtime version detection
@@ -78,32 +75,6 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/${{ matrix.artifact_name }}
-
-  # glibc 2.28 (RHEL 8 / UBI 8) — ubuntu-latest binaries need GLIBC_2.38+
-  build-binary-el8:
-    needs: lint-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build binary with PyInstaller (UBI 8)
-        run: |
-          docker run --rm -v "$PWD:/work" -w /work registry.access.redhat.com/ubi8/ubi:8.10 bash -c "
-            set -euo pipefail
-            dnf -y install python3.12 python3.12-pip gcc python3.12-devel
-            python3.12 -m pip install --upgrade pip
-            python3.12 -m pip install -r requirements.txt pyinstaller
-            python3.12 -m PyInstaller --onefile --name image-cgroupsv2-inspector-linux-amd64-el8 \
-              --add-data 'src:src' \
-              --hidden-import=src \
-              image-cgroupsv2-inspector
-          "
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: image-cgroupsv2-inspector-linux-amd64-el8
-          path: dist/image-cgroupsv2-inspector-linux-amd64-el8
 
   # ───────────────────────────────────────────────────────────────────
   # Container images — native build per arch, then manifest merge
@@ -213,7 +184,7 @@ jobs:
   # GitHub Release with all binaries attached
   # ───────────────────────────────────────────────────────────────────
   create-release:
-    needs: [build-binaries, build-binary-el8, container-manifest]
+    needs: [build-binaries, container-manifest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,6 @@ All notable changes to this project will be documented in this file.
   same layer to keep the image smaller.
 
 ### Added
-- Release: `image-cgroupsv2-inspector-linux-amd64-el8` binary built on UBI 8
-  (glibc 2.28) for RHEL 8 / Rocky 8 / AlmaLinux 8 hosts; the default
-  `linux-amd64` binary still targets newer glibc (e.g. Ubuntu 24.04).
-- CI: `binary-build-check-el8` job verifies the UBI 8 PyInstaller build on
-  every push/PR.
 - README: document the prebuilt images published on Quay.io
   (`quay.io/asalvati/image-cgroupsv2-inspector`) with a `podman pull` example.
 - CI: release workflow (`release.yml`) builds standalone binaries for

--- a/image-cgroupsv2-inspector
+++ b/image-cgroupsv2-inspector
@@ -249,6 +249,9 @@ The tool will save credentials to .env file after successful connection.
         "Only containers from matching namespaces are scanned. "
         "Supports glob patterns with * (e.g., '*-dev,*-staging'). "
         "Ignored when --namespace is specified. "
+        "Note: default exclusion patterns (openshift-*, kube-*) are applied before "
+        "this filter; to include namespaces that match those patterns, override them "
+        "with --exclude-namespaces. "
         "Default: include all namespaces (subject to --exclude-namespaces).",
     )
 
@@ -694,7 +697,7 @@ def _run_report_only(args, logger: logging.Logger) -> int:
         logger.error("Incompatible flags with --report-only: %s", incompatible)
         return 1
 
-    if not args._output_dir_is_default:
+    if not args.output_dir_is_default:
         html_dir = Path(args.output_dir) / "html"
     else:
         html_dir = csv_path.parent / "html"
@@ -771,8 +774,8 @@ def main() -> int:
     # Parse arguments
     invocation_cwd = Path.cwd()
     args = parse_arguments()
-    args._pull_secret_is_default = args.pull_secret == ".pull-secret"
-    args._output_dir_is_default = args.output_dir == "output"
+    args.pull_secret_is_default = args.pull_secret == ".pull-secret"
+    args.output_dir_is_default = args.output_dir == "output"
     _resolve_cli_paths(args, invocation_cwd)
 
     # Change to script directory for relative paths (bundled assets, default output)
@@ -955,7 +958,7 @@ def main() -> int:
                     logger.error("--analyze requires --rootfs-path")
                     return 1
 
-                pull_secret_explicitly_set = not args._pull_secret_is_default
+                pull_secret_explicitly_set = not args.pull_secret_is_default
                 if pull_secret_explicitly_set and Path(args.pull_secret).exists():
                     pull_secret_path = args.pull_secret
                     print(f"🔑 Using pull-secret: {pull_secret_path}")
@@ -1123,7 +1126,7 @@ def main() -> int:
                     logger.error("--analyze requires --rootfs-path")
                     return 1
 
-                pull_secret_explicitly_set = not args._pull_secret_is_default
+                pull_secret_explicitly_set = not args.pull_secret_is_default
                 if pull_secret_explicitly_set and Path(args.pull_secret).exists():
                     pull_secret_path = args.pull_secret
                     print(f"🔑 Using pull-secret: {pull_secret_path}")


### PR DESCRIPTION
…ve CLI

- Remove RHEL 8 binary build from CI and release workflows (unsupported platform)
- Remove RHEL 8 changelog entries erroneously added under released [2.6.0]
- Document include/exclude namespace interaction in --include-namespaces help
- Rename private _is_default attrs on argparse Namespace to public